### PR TITLE
G4 - Add STM32G4 series support (clock, peripherals, ADC, RNG, USB device)

### DIFF
--- a/include/zhele/platform/stm32/adc.h
+++ b/include/zhele/platform/stm32/adc.h
@@ -22,5 +22,8 @@
 #if defined(STM32G0)
     #include "g0/adc.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/adc.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_ADC_H

--- a/include/zhele/platform/stm32/clock.h
+++ b/include/zhele/platform/stm32/clock.h
@@ -28,5 +28,8 @@
 #if defined(STM32G0)
     #include "g0/clock.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/clock.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_CLOCK_H

--- a/include/zhele/platform/stm32/common/dac.h
+++ b/include/zhele/platform/stm32/common/dac.h
@@ -110,6 +110,14 @@ namespace Zhele
             static void DisableBuffer();
 
             /**
+             * @brief Selects high frequency interface mode by AHB clock (if supported by device)
+             * 
+             * @par Returns
+             *  Nothing
+             */
+            static void SelectHighFrequencyMode();
+
+            /**
              * @brief Enable noise wave generation
              * 
              * @param amplitude Amplitude value

--- a/include/zhele/platform/stm32/common/impl/dac.h
+++ b/include/zhele/platform/stm32/common/impl/dac.h
@@ -18,6 +18,7 @@ namespace Zhele::Private
     void DAC_TEMPLATE_QUALIFIER::Init()
     {
         _ClockCtrl::Enable();
+        SelectHighFrequencyMode();
     }
 
     DAC_TEMPLATE_ARGS
@@ -25,6 +26,7 @@ namespace Zhele::Private
     void DAC_TEMPLATE_QUALIFIER::Init(Trigger trigger)
     {
         _ClockCtrl::Enable();
+        SelectHighFrequencyMode();
         _Regs()->CR |= (DAC_CR_TEN1
                     | (static_cast<uint8_t>(trigger) << DAC_CR_TSEL1_Pos)
                 ) << (_Channel * ChannelOffset);
@@ -45,13 +47,34 @@ namespace Zhele::Private
     DAC_TEMPLATE_ARGS
     void DAC_TEMPLATE_QUALIFIER::EnableBuffer()
     {
+#if defined (DAC_CR_BOFF1)
         _Regs()->CR &= ~(DAC_CR_BOFF1 << (_Channel * ChannelOffset));
+#else
+        // MODE = 000: normal mode, connected to external pin with buffer enabled
+        _Regs()->MCR &= ~(DAC_MCR_MODE1_1 << (_Channel * ChannelOffset));
+#endif
     }
 
     DAC_TEMPLATE_ARGS
     void DAC_TEMPLATE_QUALIFIER::DisableBuffer()
     {
+#if defined (DAC_CR_BOFF1)
         _Regs()->CR |= (DAC_CR_BOFF1 << (_Channel * ChannelOffset));
+#else
+        // MODE = 010: normal mode, connected to external pin with buffer disabled
+        _Regs()->MCR |= (DAC_MCR_MODE1_1 << (_Channel * ChannelOffset));
+#endif
+    }
+
+    DAC_TEMPLATE_ARGS
+    void DAC_TEMPLATE_QUALIFIER::SelectHighFrequencyMode()
+    {
+#if defined (DAC_MCR_HFSEL)
+        // High frequency interface mode depends on AHB clock: > 160 MHz, > 80 MHz or below
+        auto ahbFreq = _ClockCtrl::ClockFreq();
+        _Regs()->MCR = (_Regs()->MCR & ~DAC_MCR_HFSEL)
+            | (ahbFreq > 160000000u ? DAC_MCR_HFSEL_1 : (ahbFreq > 80000000u ? DAC_MCR_HFSEL_0 : 0));
+#endif
     }
 
     DAC_TEMPLATE_ARGS

--- a/include/zhele/platform/stm32/common/usb/cdc.h
+++ b/include/zhele/platform/stm32/common/usb/cdc.h
@@ -121,7 +121,7 @@ namespace Zhele::Usb
          * 
          * @returns Bytes of interface descriptor
          */
-        static consteval auto FillDescriptor()
+        static consteval auto GetDescriptor()
         {
             constexpr unsigned size = sizeof(InterfaceDescriptor) + NestedDescriptorSize();
             std::array<uint8_t, size> result;

--- a/include/zhele/platform/stm32/common/usb/impl/device.h
+++ b/include/zhele/platform/stm32/common/usb/impl/device.h
@@ -443,12 +443,15 @@ namespace Zhele::Usb
     IO_STRUCT_WRAPPER(USB_OTG_FS_PERIPH_BASE + USB_OTG_DEVICE_BASE, UsbDeviceRegs, USB_OTG_DeviceTypeDef);
 #endif
 
-#if defined (USB_LP_IRQn)
-    #define USB_IRQ USB_LP_IRQn
-#elif defined (USB)
+// USB_LP_IRQn/USB_HP_IRQn (split low/high priority IRQ, e.g. STM32G4) are IRQn_Type
+// enumerators, not preprocessor macros, so `defined(USB_LP_IRQn)` can't detect them:
+// a family header must `#define USB_IRQ` itself before including this file in that case.
+#if !defined (USB_IRQ)
+#if defined (USB)
     #define USB_IRQ USB_IRQn
 #elif defined (USB_OTG_FS)
     #define USB_IRQ OTG_FS_IRQn
+#endif
 #endif
 
 #if defined (USB)

--- a/include/zhele/platform/stm32/common/usb/impl/device.h
+++ b/include/zhele/platform/stm32/common/usb/impl/device.h
@@ -443,11 +443,14 @@ namespace Zhele::Usb
     IO_STRUCT_WRAPPER(USB_OTG_FS_PERIPH_BASE + USB_OTG_DEVICE_BASE, UsbDeviceRegs, USB_OTG_DeviceTypeDef);
 #endif
 
-// USB_LP_IRQn/USB_HP_IRQn (split low/high priority IRQ, e.g. STM32G4) are IRQn_Type
-// enumerators, not preprocessor macros, so `defined(USB_LP_IRQn)` can't detect them:
-// a family header must `#define USB_IRQ` itself before including this file in that case.
+// On some families (e.g. STM32F1) USB_LP_IRQn/USB_HP_IRQn are preprocessor macros and
+// `defined(USB_LP_IRQn)` correctly detects them. On others (e.g. STM32G4) they are
+// IRQn_Type enumerators, invisible to `#if defined()` - such a family header must
+// `#define USB_IRQ` itself before including this file, which the guard below respects.
 #if !defined (USB_IRQ)
-#if defined (USB)
+#if defined (USB_LP_IRQn)
+    #define USB_IRQ USB_LP_IRQn
+#elif defined (USB)
     #define USB_IRQ USB_IRQn
 #elif defined (USB_OTG_FS)
     #define USB_IRQ OTG_FS_IRQn

--- a/include/zhele/platform/stm32/crc.h
+++ b/include/zhele/platform/stm32/crc.h
@@ -21,6 +21,9 @@
 #if defined(STM32G0)
     #include <stm32g0xx.h>
 #endif
+#if defined(STM32G4)
+    #include <stm32g4xx.h>
+#endif
 
 #include "common/crc.h"
 

--- a/include/zhele/platform/stm32/dac.h
+++ b/include/zhele/platform/stm32/dac.h
@@ -25,5 +25,8 @@
 #if defined(STM32G0)
     #include "g0/dac.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/dac.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_DAC_H

--- a/include/zhele/platform/stm32/delay.h
+++ b/include/zhele/platform/stm32/delay.h
@@ -28,5 +28,8 @@
 #if defined(STM32G0)
     #include "g0/delay.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/delay.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_DELAY_H

--- a/include/zhele/platform/stm32/dma.h
+++ b/include/zhele/platform/stm32/dma.h
@@ -25,6 +25,9 @@
 #if defined(STM32G0)
     #include "g0/dma.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/dma.h"
+#endif
 #if defined(STM32C0)
     #include "c0/dma.h"
 #endif

--- a/include/zhele/platform/stm32/dmamux.h
+++ b/include/zhele/platform/stm32/dmamux.h
@@ -22,6 +22,9 @@
 #if defined(STM32G0)
     #include "g0/dmamux.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/dmamux.h"
+#endif
 #if defined(STM32C0)
     #include "c0/dmamux.h"
 #endif

--- a/include/zhele/platform/stm32/exti.h
+++ b/include/zhele/platform/stm32/exti.h
@@ -25,5 +25,8 @@
 #if defined(STM32G0)
     #include "g0/exti.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/exti.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_EXTI_H

--- a/include/zhele/platform/stm32/flash.h
+++ b/include/zhele/platform/stm32/flash.h
@@ -28,5 +28,8 @@
 #if defined(STM32G0)
     #include "g0/flash.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/flash.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_FLASH_H

--- a/include/zhele/platform/stm32/g4/adc.h
+++ b/include/zhele/platform/stm32/g4/adc.h
@@ -1,0 +1,464 @@
+/**
+ * @file
+ * @brief Implements ADC for stm32g4 series
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ *
+ * @details
+ * The G4 ADC IP (SAR ADC with ADEN/ADCAL/ISR/ CFGR/SQRx/SMPRx registers) is not compatible
+ * with the register layout the common ADC engine (../common/adc.h) was written for
+ * (F1-style SR/CR1/CR2/SQRx registers), so this is a self-contained driver instead of an
+ * instantiation of Private::AdcBase.
+ *
+ * Not implemented in this version: injected channels, external triggers, oversampling,
+ * differential mode, dual (simultaneous) mode. Internal channels (temperature sensor,
+ * VBAT, VREFINT) are only wired to ADC1 (and ADC5 on some devices) — see RM0440.
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_ADC_H
+#define ZHELE_PLATFORM_STM32_G4_ADC_H
+
+#include <stm32g4xx.h>
+
+#include "clock.h"
+#include "dma.h"
+#include "iopins.h"
+
+#include <zhele/delay.h>
+#include <zhele/pinlist.h>
+
+#include "../common/adc.h"
+
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+namespace Zhele
+{
+    namespace Private
+    {
+        /// Factory calibration values (RM0440 §21.4.34, DS12589/DS12288)
+        static constexpr uint32_t Adc_VrefintCalAddr = 0x1FFF75AAUL;
+        static constexpr uint32_t Adc_TempSensorCal1Addr = 0x1FFF75A8UL;
+        static constexpr uint32_t Adc_TempSensorCal2Addr = 0x1FFF75CAUL;
+        static constexpr int32_t Adc_TempSensorCal1Temp = 30;
+        static constexpr int32_t Adc_TempSensorCal2Temp = 110;
+        static constexpr uint16_t Adc_VrefintCalVref = 3000; // mV, Vdda at which VREFINT/TS were calibrated
+
+        /**
+         * @brief Implements STM32G4 ADC (SAR ADC, ADEN/ADCAL-based)
+         *
+         * @tparam _Regs ADC instance register wrapper
+         * @tparam _CommonRegs ADC12_COMMON/ADC345_COMMON register wrapper (shared by a pair of ADCs)
+         * @tparam _ClockCtrl Clock control (Clock::Adc12Clock or Clock::Adc345Clock)
+         * @tparam _IRQn ADC IRQ number
+         * @tparam _PinMap Pin map: exposes `io_pins` (PinList of bonded input pins) and a
+         *         `channels` array giving the ADC channel number for each pin (by index)
+         * @tparam _DmaChannel DMA channel used for StartRegular()/StopRegular() (optional)
+         */
+        template<typename _Regs, typename _CommonRegs, typename _ClockCtrl, IRQn_Type _IRQn, typename _PinMap, typename _DmaChannel = void>
+        class AdcG4 : public AdcCommon
+        {
+        public:
+            static const uint8_t ResolutionBits = 12;
+
+            // Internal channels (ADC1 only, see RM0440 §21.4.19)
+            static const uint8_t TempSensorChannel = 16;
+            static const uint8_t VBatChannel = 17;
+            static const uint8_t ReferenceChannel = 18;
+
+            /**
+             * @brief Initializes ADC: enables clock, exits deep-power-down, enables the
+             * voltage regulator, calibrates (single-ended), configures input pins as
+             * analog and enables the ADC (ADEN)
+             *
+             * @par Returns
+             *  Nothing
+             */
+            static void Init();
+
+            /**
+             * @brief Sets sample time for given channel
+             *
+             * @param channel Channel number (0..18)
+             * @param sampleTime Sample time selector (0..7, see ADC_SMPR1_SMPx)
+             *
+             * @par Returns
+             *  Nothing
+             */
+            static void SetSampleTime(uint8_t channel, uint8_t sampleTime);
+
+            /**
+             * @brief Sets sample time for channel connected to given pin
+             */
+            template<typename Pin>
+            static void SetSampleTime(uint8_t sampleTime);
+
+            /**
+             * @brief Returns ADC channel number for given pin (compile time)
+             */
+            template<typename Pin>
+            static constexpr uint8_t ChannelNum();
+
+            /**
+             * @brief Performs single blocking conversion on given channel
+             *
+             * @param channel Channel number
+             *
+             * @returns Raw conversion result (12 bit)
+             */
+            static uint16_t ReadSingle(uint8_t channel);
+
+            /**
+             * @brief Performs single blocking conversion on channel connected to given pin
+             */
+            template<typename Pin>
+            static uint16_t ReadSingle();
+
+            /**
+             * @brief Starts continuous regular sequence conversion with DMA transfer
+             *
+             * @param channels Channels array
+             * @param channelsCount Channels count (1..16)
+             * @param dataBuffer Destination buffer (size must be at least channelsCount * scanCount)
+             * @param scanCount Sequence repeats stored in buffer before DMA circles back
+             *
+             * @retval true Started
+             * @retval false Invalid arguments
+             */
+            static bool StartRegular(const uint8_t* channels, uint8_t channelsCount, uint16_t* dataBuffer, uint16_t scanCount);
+
+            /**
+             * @brief Stops regular sequence conversion started by StartRegular()
+             *
+             * @par Returns
+             *  Nothing
+             */
+            static void StopRegular();
+
+            /**
+             * @brief Enables VREFINT path (common to the ADC pair)
+             */
+            static void EnableVref();
+            static void DisableVref();
+
+            /**
+             * @brief Enables temperature sensor path (common to the ADC pair, ADC1 only)
+             */
+            static void EnableTemperatureSensor();
+            static void DisableTemperatureSensor();
+
+            /**
+             * @brief Enables VBAT/3 path (common to the ADC pair, ADC1 only)
+             */
+            static void EnableVBat();
+            static void DisableVBat();
+
+            /**
+             * @brief Measures actual Vdda (mV) via VREFINT and factory calibration value,
+             * caches it for ToVolts()/ReadTemperature()
+             *
+             * @returns Measured Vdda in millivolts
+             */
+            static uint16_t MeasureVdda();
+
+            /**
+             * @brief Converts raw conversion result to millivolts (uses nominal 3300 mV
+             * Vdda unless MeasureVdda() was called before)
+             */
+            static unsigned ToVolts(uint16_t value);
+
+            /**
+             * @brief Reads internal temperature sensor (ADC1 only)
+             *
+             * @returns Temperature, degrees Celsius
+             */
+            static int16_t ReadTemperature();
+
+            /**
+             * @brief Clears pending interrupt flags (EOC/EOS/OVR/...)
+             *
+             * @par Returns
+             *  Nothing
+             */
+            static void IrqHandler();
+
+        private:
+            static void Calibrate();
+            static void WriteSequenceSlot(uint8_t index, uint8_t channel);
+
+            static inline uint16_t _vddaMv = 3300;
+        };
+    }
+
+    struct Adc1Pins
+    {
+        using io_pins = IO::PinList<IO::Pa0, IO::Pa1, IO::Pa2, IO::Pb14, IO::Pc0, IO::Pc1, IO::Pc2, IO::Pc3, IO::Pf0, IO::Pb12, IO::Pb1, IO::Pb0>;
+        static constexpr std::array<uint8_t, 12> channels{1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 15};
+    };
+
+    struct Adc2Pins
+    {
+        using io_pins = IO::PinList<IO::Pa0, IO::Pa1, IO::Pa6, IO::Pa7, IO::Pc4, IO::Pc0, IO::Pc1, IO::Pc2, IO::Pc3, IO::Pf1, IO::Pc5, IO::Pb2, IO::Pa5, IO::Pb15, IO::Pa4>;
+        static constexpr std::array<uint8_t, 15> channels{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 17};
+    };
+
+    namespace Private
+    {
+        IO_STRUCT_WRAPPER(ADC1, Adc1Regs, ADC_TypeDef);
+        IO_STRUCT_WRAPPER(ADC2, Adc2Regs, ADC_TypeDef);
+        IO_STRUCT_WRAPPER(ADC12_COMMON, Adc12CommonRegs, ADC_Common_TypeDef);
+    }
+
+    template<typename _DmaChannel = void>
+    using Adc1 = Private::AdcG4<Private::Adc1Regs, Private::Adc12CommonRegs, Clock::Adc12Clock, ADC1_2_IRQn, Adc1Pins, _DmaChannel>;
+    using Adc1NoDma = Adc1<>;
+
+    template<typename _DmaChannel = void>
+    using Adc2 = Private::AdcG4<Private::Adc2Regs, Private::Adc12CommonRegs, Clock::Adc12Clock, ADC1_2_IRQn, Adc2Pins, _DmaChannel>;
+    using Adc2NoDma = Adc2<>;
+
+#if defined (ADC3)
+    // Category 3/4 devices (G47x/G48x/G49x). Pin maps below list only the channels bonded
+    // on the LQFP64 package; extend for other packages/channels if needed.
+    struct Adc3Pins
+    {
+        using io_pins = IO::PinList<IO::Pb1, IO::Pb13, IO::Pb0>;
+        static constexpr std::array<uint8_t, 3> channels{1, 5, 12};
+    };
+    struct Adc4Pins
+    {
+        using io_pins = IO::PinList<IO::Pb12, IO::Pb14, IO::Pb15>;
+        static constexpr std::array<uint8_t, 3> channels{3, 4, 5};
+    };
+    struct Adc5Pins
+    {
+        using io_pins = IO::PinList<IO::Pa8, IO::Pa9>;
+        static constexpr std::array<uint8_t, 2> channels{1, 2};
+    };
+
+    namespace Private
+    {
+        IO_STRUCT_WRAPPER(ADC3, Adc3Regs, ADC_TypeDef);
+        IO_STRUCT_WRAPPER(ADC4, Adc4Regs, ADC_TypeDef);
+        IO_STRUCT_WRAPPER(ADC5, Adc5Regs, ADC_TypeDef);
+        IO_STRUCT_WRAPPER(ADC345_COMMON, Adc345CommonRegs, ADC_Common_TypeDef);
+    }
+
+    template<typename _DmaChannel = void>
+    using Adc3 = Private::AdcG4<Private::Adc3Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, ADC3_IRQn, Adc3Pins, _DmaChannel>;
+    using Adc3NoDma = Adc3<>;
+
+    template<typename _DmaChannel = void>
+    using Adc4 = Private::AdcG4<Private::Adc4Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, ADC4_IRQn, Adc4Pins, _DmaChannel>;
+    using Adc4NoDma = Adc4<>;
+
+    template<typename _DmaChannel = void>
+    using Adc5 = Private::AdcG4<Private::Adc5Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, ADC5_IRQn, Adc5Pins, _DmaChannel>;
+    using Adc5NoDma = Adc5<>;
+#endif
+}
+
+namespace Zhele::Private
+{
+    #define ADCG4_TEMPLATE_ARGS template<typename _Regs, typename _CommonRegs, typename _ClockCtrl, IRQn_Type _IRQn, typename _PinMap, typename _DmaChannel>
+    #define ADCG4_TEMPLATE_QUALIFIER AdcG4<_Regs, _CommonRegs, _ClockCtrl, _IRQn, _PinMap, _DmaChannel>
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::Calibrate()
+    {
+        _Regs()->CR &= ~ADC_CR_ADCALDIF;
+        _Regs()->CR |= ADC_CR_ADCAL;
+        while ((_Regs()->CR & ADC_CR_ADCAL) != 0) continue;
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::Init()
+    {
+        _ClockCtrl::Enable();
+
+        // Synchronous clock, HCLK/4 (safe up to 170 MHz AHB, ADC clock <= 60 MHz)
+        _CommonRegs()->CCR = (_CommonRegs()->CCR & ~ADC_CCR_CKMODE) | ADC_CCR_CKMODE_0 | ADC_CCR_CKMODE_1;
+
+        _Regs()->CR &= ~ADC_CR_DEEPPWD;
+        _Regs()->CR |= ADC_CR_ADVREGEN;
+        delay_us<20>(); // tADCVREG_STUP
+
+        Calibrate();
+
+        _PinMap::io_pins::Enable();
+        _PinMap::io_pins::SetConfiguration(_PinMap::io_pins::Configuration::Analog);
+
+        _Regs()->ISR = ADC_ISR_ADRDY;
+        _Regs()->CR |= ADC_CR_ADEN;
+        while ((_Regs()->ISR & ADC_ISR_ADRDY) == 0) continue;
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::SetSampleTime(uint8_t channel, uint8_t sampleTime)
+    {
+        uint32_t value = static_cast<uint32_t>(sampleTime & 0x7);
+        if (channel <= 9)
+        {
+            uint32_t shift = channel * 3u;
+            _Regs()->SMPR1 = (_Regs()->SMPR1 & ~(0x7u << shift)) | (value << shift);
+        }
+        else
+        {
+            uint32_t shift = (channel - 10u) * 3u;
+            _Regs()->SMPR2 = (_Regs()->SMPR2 & ~(0x7u << shift)) | (value << shift);
+        }
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    template<typename Pin>
+    void ADCG4_TEMPLATE_QUALIFIER::SetSampleTime(uint8_t sampleTime)
+    {
+        SetSampleTime(ChannelNum<Pin>(), sampleTime);
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    template<typename Pin>
+    constexpr uint8_t ADCG4_TEMPLATE_QUALIFIER::ChannelNum()
+    {
+        constexpr int index = _PinMap::io_pins::template IndexOf<Pin>;
+        static_assert(index >= 0, "Pin is not a member of this ADC's pin map");
+        return _PinMap::channels[index];
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::WriteSequenceSlot(uint8_t index, uint8_t channel)
+    {
+        uint32_t value = static_cast<uint32_t>(channel & 0x1F);
+        if (index < 4)
+            _Regs()->SQR1 |= value << (6 + index * 6);
+        else if (index < 9)
+            _Regs()->SQR2 |= value << ((index - 4) * 6);
+        else if (index < 14)
+            _Regs()->SQR3 |= value << ((index - 9) * 6);
+        else
+            _Regs()->SQR4 |= value << ((index - 14) * 6);
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    uint16_t ADCG4_TEMPLATE_QUALIFIER::ReadSingle(uint8_t channel)
+    {
+        _Regs()->SQR1 = static_cast<uint32_t>(channel & 0x1F) << ADC_SQR1_SQ1_Pos;
+        _Regs()->ISR = ADC_ISR_EOC | ADC_ISR_EOS;
+        _Regs()->CR |= ADC_CR_ADSTART;
+        while ((_Regs()->ISR & ADC_ISR_EOC) == 0) continue;
+        return static_cast<uint16_t>(_Regs()->DR);
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    template<typename Pin>
+    uint16_t ADCG4_TEMPLATE_QUALIFIER::ReadSingle()
+    {
+        return ReadSingle(ChannelNum<Pin>());
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    bool ADCG4_TEMPLATE_QUALIFIER::StartRegular(const uint8_t* channels, uint8_t channelsCount, uint16_t* dataBuffer, uint16_t scanCount)
+    {
+        static_assert(!std::is_void_v<_DmaChannel>, "StartRegular requires a DMA channel");
+
+        if (channelsCount == 0 || channelsCount > MaxRegular || dataBuffer == nullptr || scanCount == 0)
+            return false;
+
+        _Regs()->SQR1 = 0;
+        _Regs()->SQR2 = 0;
+        _Regs()->SQR3 = 0;
+        _Regs()->SQR4 = 0;
+        for (uint8_t i = 0; i < channelsCount; ++i)
+            WriteSequenceSlot(i, channels[i]);
+        _Regs()->SQR1 = (_Regs()->SQR1 & ~ADC_SQR1_L) | (static_cast<uint32_t>(channelsCount - 1) << ADC_SQR1_L_Pos);
+
+        _Regs()->CFGR = (_Regs()->CFGR & ~(ADC_CFGR_CONT | ADC_CFGR_DMAEN | ADC_CFGR_DMACFG))
+            | ADC_CFGR_CONT | ADC_CFGR_DMAEN | ADC_CFGR_DMACFG;
+
+        _DmaChannel::Transfer(
+            _DmaChannel::Periph2Mem | _DmaChannel::MemIncrement | _DmaChannel::Circular
+                | _DmaChannel::PSize16Bits | _DmaChannel::MSize16Bits,
+            dataBuffer, &_Regs()->DR, static_cast<uint32_t>(channelsCount) * scanCount);
+
+        _Regs()->CR |= ADC_CR_ADSTART;
+
+        return true;
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::StopRegular()
+    {
+        static_assert(!std::is_void_v<_DmaChannel>, "StopRegular requires a DMA channel");
+
+        if ((_Regs()->CR & ADC_CR_ADSTART) != 0)
+        {
+            _Regs()->CR |= ADC_CR_ADSTP;
+            while ((_Regs()->CR & ADC_CR_ADSTP) != 0) continue;
+        }
+        _Regs()->CFGR &= ~(ADC_CFGR_CONT | ADC_CFGR_DMAEN | ADC_CFGR_DMACFG);
+        _DmaChannel::Disable();
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::EnableVref() { _CommonRegs()->CCR |= ADC_CCR_VREFEN; }
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::DisableVref() { _CommonRegs()->CCR &= ~ADC_CCR_VREFEN; }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::EnableTemperatureSensor() { _CommonRegs()->CCR |= ADC_CCR_VSENSESEL; }
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::DisableTemperatureSensor() { _CommonRegs()->CCR &= ~ADC_CCR_VSENSESEL; }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::EnableVBat() { _CommonRegs()->CCR |= ADC_CCR_VBATSEL; }
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::DisableVBat() { _CommonRegs()->CCR &= ~ADC_CCR_VBATSEL; }
+
+    ADCG4_TEMPLATE_ARGS
+    uint16_t ADCG4_TEMPLATE_QUALIFIER::MeasureVdda()
+    {
+        EnableVref();
+        delay_us<12>(); // tSTART, VREFINT
+        uint16_t raw = ReadSingle(ReferenceChannel);
+        uint16_t cal = *reinterpret_cast<const volatile uint16_t*>(Adc_VrefintCalAddr);
+        _vddaMv = static_cast<uint16_t>((static_cast<uint32_t>(Adc_VrefintCalVref) * cal) / raw);
+        return _vddaMv;
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    unsigned ADCG4_TEMPLATE_QUALIFIER::ToVolts(uint16_t value)
+    {
+        return static_cast<unsigned>(value) * _vddaMv / ((1u << ResolutionBits) - 1);
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    int16_t ADCG4_TEMPLATE_QUALIFIER::ReadTemperature()
+    {
+        EnableTemperatureSensor();
+        delay_us<10>(); // tSTART, temperature sensor
+        uint16_t raw = ReadSingle(TempSensorChannel);
+        uint16_t cal1 = *reinterpret_cast<const volatile uint16_t*>(Adc_TempSensorCal1Addr);
+        uint16_t cal2 = *reinterpret_cast<const volatile uint16_t*>(Adc_TempSensorCal2Addr);
+
+        // Correct raw value for actual Vdda vs the 3.0 V factory calibration condition
+        int32_t correctedRaw = static_cast<int32_t>(raw) * static_cast<int32_t>(_vddaMv) / Adc_VrefintCalVref;
+
+        return static_cast<int16_t>(
+            ((correctedRaw - static_cast<int32_t>(cal1)) * (Adc_TempSensorCal2Temp - Adc_TempSensorCal1Temp))
+                / (static_cast<int32_t>(cal2) - static_cast<int32_t>(cal1))
+            + Adc_TempSensorCal1Temp);
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    void ADCG4_TEMPLATE_QUALIFIER::IrqHandler()
+    {
+        _Regs()->ISR = _Regs()->ISR;
+    }
+
+    #undef ADCG4_TEMPLATE_ARGS
+    #undef ADCG4_TEMPLATE_QUALIFIER
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_ADC_H

--- a/include/zhele/platform/stm32/g4/adc.h
+++ b/include/zhele/platform/stm32/g4/adc.h
@@ -111,13 +111,34 @@ namespace Zhele
             static uint16_t ReadSingle(uint8_t channel);
 
             /**
+             * @brief Switches given pin to analog mode
+             *
+             * @details
+             * Not done automatically for the whole pin map in Init(): a pin map can list
+             * pins shared with other peripherals (e.g. a USART on the same physical pin),
+             * so only pins actually used for conversion are switched to analog, and only
+             * on demand. Called automatically by ReadSingle<Pin>(); call explicitly before
+             * StartRegular() for every pin used in the channel list.
+             *
+             * @par Returns
+             *  Nothing
+             */
+            template<typename Pin>
+            static void ConfigureAnalogPin();
+
+            /**
              * @brief Performs single blocking conversion on channel connected to given pin
+             * (switches the pin to analog mode first, see ConfigureAnalogPin())
              */
             template<typename Pin>
             static uint16_t ReadSingle();
 
             /**
              * @brief Starts continuous regular sequence conversion with DMA transfer
+             *
+             * @details
+             * Pins for the given channels must already be configured as analog
+             * (see ConfigureAnalogPin()) — this method only touches ADC registers.
              *
              * @param channels Channels array
              * @param channelsCount Channels count (1..16)
@@ -287,12 +308,21 @@ namespace Zhele::Private
 
         Calibrate();
 
-        _PinMap::io_pins::Enable();
-        _PinMap::io_pins::SetConfiguration(_PinMap::io_pins::Configuration::Analog);
+        // Input pins are NOT configured here: this instance's pin map can list pins that
+        // are shared with other peripherals (e.g. a USART on the same physical pin), and
+        // blanket-configuring all of them as analog would silently steal such a pin.
+        // Pins are switched to analog mode lazily, only for the channel actually read
+        // (see ReadSingle<Pin>()/ConfigureAnalogPin()).
 
         _Regs()->ISR = ADC_ISR_ADRDY;
         _Regs()->CR |= ADC_CR_ADEN;
-        while ((_Regs()->ISR & ADC_ISR_ADRDY) == 0) continue;
+        // If ADEN is set less than 4 ADC clock cycles after ADCAL was cleared, the
+        // calibration logic silently resets it: keep re-asserting ADEN until ADRDY sets.
+        while ((_Regs()->ISR & ADC_ISR_ADRDY) == 0)
+        {
+            if ((_Regs()->CR & ADC_CR_ADEN) == 0)
+                _Regs()->CR |= ADC_CR_ADEN;
+        }
     }
 
     ADCG4_TEMPLATE_ARGS
@@ -353,8 +383,18 @@ namespace Zhele::Private
 
     ADCG4_TEMPLATE_ARGS
     template<typename Pin>
+    void ADCG4_TEMPLATE_QUALIFIER::ConfigureAnalogPin()
+    {
+        static_assert(_PinMap::io_pins::template IndexOf<Pin> >= 0, "Pin is not a member of this ADC's pin map");
+        Pin::Port::Enable();
+        Pin::template SetConfiguration<Pin::Configuration::Analog>();
+    }
+
+    ADCG4_TEMPLATE_ARGS
+    template<typename Pin>
     uint16_t ADCG4_TEMPLATE_QUALIFIER::ReadSingle()
     {
+        ConfigureAnalogPin<Pin>();
         return ReadSingle(ChannelNum<Pin>());
     }
 
@@ -421,6 +461,9 @@ namespace Zhele::Private
     {
         EnableVref();
         delay_us<12>(); // tSTART, VREFINT
+        // Internal channels have high source impedance: use the longest sample time
+        // (640.5 ADC cycles), matching the conditions TS_CAL/VREFINT_CAL were measured at.
+        SetSampleTime(ReferenceChannel, 0b111);
         uint16_t raw = ReadSingle(ReferenceChannel);
         uint16_t cal = *reinterpret_cast<const volatile uint16_t*>(Adc_VrefintCalAddr);
         _vddaMv = static_cast<uint16_t>((static_cast<uint32_t>(Adc_VrefintCalVref) * cal) / raw);
@@ -437,7 +480,8 @@ namespace Zhele::Private
     int16_t ADCG4_TEMPLATE_QUALIFIER::ReadTemperature()
     {
         EnableTemperatureSensor();
-        delay_us<10>(); // tSTART, temperature sensor
+        delay_us<120>(); // tS_TEMPSENSOR (temperature sensor buffer stabilization time)
+        SetSampleTime(TempSensorChannel, 0b111); // 640.5 ADC cycles, see MeasureVdda()
         uint16_t raw = ReadSingle(TempSensorChannel);
         uint16_t cal1 = *reinterpret_cast<const volatile uint16_t*>(Adc_TempSensorCal1Addr);
         uint16_t cal2 = *reinterpret_cast<const volatile uint16_t*>(Adc_TempSensorCal2Addr);

--- a/include/zhele/platform/stm32/g4/adc.h
+++ b/include/zhele/platform/stm32/g4/adc.h
@@ -25,6 +25,7 @@
 #include "dma.h"
 #include "iopins.h"
 
+#include <zhele/common/template_utils/type_list.h>
 #include <zhele/delay.h>
 #include <zhele/pinlist.h>
 
@@ -46,20 +47,33 @@ namespace Zhele
         static constexpr int32_t Adc_TempSensorCal2Temp = 110;
         static constexpr uint16_t Adc_VrefintCalVref = 3000; // mV, Vdda at which VREFINT/TS were calibrated
 
+        /// Wraps an IRQn_Type value as a type, so it can join a homogeneous type parameter pack
+        template<IRQn_Type V>
+        using Irq = std::integral_constant<IRQn_Type, V>;
+
         /**
          * @brief Implements STM32G4 ADC (SAR ADC, ADEN/ADCAL-based)
          *
-         * @tparam _Regs ADC instance register wrapper
-         * @tparam _CommonRegs ADC12_COMMON/ADC345_COMMON register wrapper (shared by a pair of ADCs)
-         * @tparam _ClockCtrl Clock control (Clock::Adc12Clock or Clock::Adc345Clock)
-         * @tparam _IRQn ADC IRQ number
-         * @tparam _PinMap Pin map: exposes `io_pins` (PinList of bonded input pins) and a
-         *         `channels` array giving the ADC channel number for each pin (by index)
-         * @tparam _DmaChannel DMA channel used for StartRegular()/StopRegular() (optional)
+         * @tparam _Params Packed as (_Regs, _CommonRegs, _ClockCtrl, _IRQn, _PinMap, _DmaChannel):
+         *         _Regs ADC instance register wrapper;
+         *         _CommonRegs ADC12_COMMON/ADC345_COMMON register wrapper (shared by a pair of ADCs);
+         *         _ClockCtrl Clock control (Clock::Adc12Clock or Clock::Adc345Clock);
+         *         _IRQn ADC IRQ number, wrapped as Irq<V>;
+         *         _PinMap Pin map: exposes `io_pins` (PinList of bonded input pins) and a
+         *         `channels` array giving the ADC channel number for each pin (by index);
+         *         _DmaChannel DMA channel used for StartRegular()/StopRegular() (optional, default void)
          */
-        template<typename _Regs, typename _CommonRegs, typename _ClockCtrl, IRQn_Type _IRQn, typename _PinMap, typename _DmaChannel = void>
+        template<typename... _Params>
         class AdcG4 : public AdcCommon
         {
+            using _Args = Zhele::template_utils::type_list<_Params...>;
+            using _Regs = Zhele::template_utils::type_unbox<_Args::template get<0>()>;
+            using _CommonRegs = Zhele::template_utils::type_unbox<_Args::template get<1>()>;
+            using _ClockCtrl = Zhele::template_utils::type_unbox<_Args::template get<2>()>;
+            static constexpr IRQn_Type _IRQn = Zhele::template_utils::type_unbox<_Args::template get<3>()>::value;
+            using _PinMap = Zhele::template_utils::type_unbox<_Args::template get<4>()>;
+            using _DmaChannel = Zhele::template_utils::type_unbox<_Args::template get<5>()>;
+
         public:
             static const uint8_t ResolutionBits = 12;
 
@@ -233,11 +247,11 @@ namespace Zhele
     }
 
     template<typename _DmaChannel = void>
-    using Adc1 = Private::AdcG4<Private::Adc1Regs, Private::Adc12CommonRegs, Clock::Adc12Clock, ADC1_2_IRQn, Adc1Pins, _DmaChannel>;
+    using Adc1 = Private::AdcG4<Private::Adc1Regs, Private::Adc12CommonRegs, Clock::Adc12Clock, Private::Irq<ADC1_2_IRQn>, Adc1Pins, _DmaChannel>;
     using Adc1NoDma = Adc1<>;
 
     template<typename _DmaChannel = void>
-    using Adc2 = Private::AdcG4<Private::Adc2Regs, Private::Adc12CommonRegs, Clock::Adc12Clock, ADC1_2_IRQn, Adc2Pins, _DmaChannel>;
+    using Adc2 = Private::AdcG4<Private::Adc2Regs, Private::Adc12CommonRegs, Clock::Adc12Clock, Private::Irq<ADC1_2_IRQn>, Adc2Pins, _DmaChannel>;
     using Adc2NoDma = Adc2<>;
 
 #if defined (ADC3)
@@ -268,34 +282,31 @@ namespace Zhele
     }
 
     template<typename _DmaChannel = void>
-    using Adc3 = Private::AdcG4<Private::Adc3Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, ADC3_IRQn, Adc3Pins, _DmaChannel>;
+    using Adc3 = Private::AdcG4<Private::Adc3Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, Private::Irq<ADC3_IRQn>, Adc3Pins, _DmaChannel>;
     using Adc3NoDma = Adc3<>;
 
     template<typename _DmaChannel = void>
-    using Adc4 = Private::AdcG4<Private::Adc4Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, ADC4_IRQn, Adc4Pins, _DmaChannel>;
+    using Adc4 = Private::AdcG4<Private::Adc4Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, Private::Irq<ADC4_IRQn>, Adc4Pins, _DmaChannel>;
     using Adc4NoDma = Adc4<>;
 
     template<typename _DmaChannel = void>
-    using Adc5 = Private::AdcG4<Private::Adc5Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, ADC5_IRQn, Adc5Pins, _DmaChannel>;
+    using Adc5 = Private::AdcG4<Private::Adc5Regs, Private::Adc345CommonRegs, Clock::Adc345Clock, Private::Irq<ADC5_IRQn>, Adc5Pins, _DmaChannel>;
     using Adc5NoDma = Adc5<>;
 #endif
 }
 
 namespace Zhele::Private
 {
-    #define ADCG4_TEMPLATE_ARGS template<typename _Regs, typename _CommonRegs, typename _ClockCtrl, IRQn_Type _IRQn, typename _PinMap, typename _DmaChannel>
-    #define ADCG4_TEMPLATE_QUALIFIER AdcG4<_Regs, _CommonRegs, _ClockCtrl, _IRQn, _PinMap, _DmaChannel>
-
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::Calibrate()
+    template<typename... _Params>
+    void AdcG4<_Params...>::Calibrate()
     {
         _Regs()->CR &= ~ADC_CR_ADCALDIF;
         _Regs()->CR |= ADC_CR_ADCAL;
         while ((_Regs()->CR & ADC_CR_ADCAL) != 0) continue;
     }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::Init()
+    template<typename... _Params>
+    void AdcG4<_Params...>::Init()
     {
         _ClockCtrl::Enable();
 
@@ -325,8 +336,8 @@ namespace Zhele::Private
         }
     }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::SetSampleTime(uint8_t channel, uint8_t sampleTime)
+    template<typename... _Params>
+    void AdcG4<_Params...>::SetSampleTime(uint8_t channel, uint8_t sampleTime)
     {
         uint32_t value = static_cast<uint32_t>(sampleTime & 0x7);
         if (channel <= 9)
@@ -341,24 +352,24 @@ namespace Zhele::Private
         }
     }
 
-    ADCG4_TEMPLATE_ARGS
+    template<typename... _Params>
     template<typename Pin>
-    void ADCG4_TEMPLATE_QUALIFIER::SetSampleTime(uint8_t sampleTime)
+    void AdcG4<_Params...>::SetSampleTime(uint8_t sampleTime)
     {
         SetSampleTime(ChannelNum<Pin>(), sampleTime);
     }
 
-    ADCG4_TEMPLATE_ARGS
+    template<typename... _Params>
     template<typename Pin>
-    constexpr uint8_t ADCG4_TEMPLATE_QUALIFIER::ChannelNum()
+    constexpr uint8_t AdcG4<_Params...>::ChannelNum()
     {
         constexpr int index = _PinMap::io_pins::template IndexOf<Pin>;
         static_assert(index >= 0, "Pin is not a member of this ADC's pin map");
         return _PinMap::channels[index];
     }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::WriteSequenceSlot(uint8_t index, uint8_t channel)
+    template<typename... _Params>
+    void AdcG4<_Params...>::WriteSequenceSlot(uint8_t index, uint8_t channel)
     {
         uint32_t value = static_cast<uint32_t>(channel & 0x1F);
         if (index < 4)
@@ -371,8 +382,8 @@ namespace Zhele::Private
             _Regs()->SQR4 |= value << ((index - 14) * 6);
     }
 
-    ADCG4_TEMPLATE_ARGS
-    uint16_t ADCG4_TEMPLATE_QUALIFIER::ReadSingle(uint8_t channel)
+    template<typename... _Params>
+    uint16_t AdcG4<_Params...>::ReadSingle(uint8_t channel)
     {
         _Regs()->SQR1 = static_cast<uint32_t>(channel & 0x1F) << ADC_SQR1_SQ1_Pos;
         _Regs()->ISR = ADC_ISR_EOC | ADC_ISR_EOS;
@@ -381,25 +392,25 @@ namespace Zhele::Private
         return static_cast<uint16_t>(_Regs()->DR);
     }
 
-    ADCG4_TEMPLATE_ARGS
+    template<typename... _Params>
     template<typename Pin>
-    void ADCG4_TEMPLATE_QUALIFIER::ConfigureAnalogPin()
+    void AdcG4<_Params...>::ConfigureAnalogPin()
     {
         static_assert(_PinMap::io_pins::template IndexOf<Pin> >= 0, "Pin is not a member of this ADC's pin map");
         Pin::Port::Enable();
         Pin::template SetConfiguration<Pin::Configuration::Analog>();
     }
 
-    ADCG4_TEMPLATE_ARGS
+    template<typename... _Params>
     template<typename Pin>
-    uint16_t ADCG4_TEMPLATE_QUALIFIER::ReadSingle()
+    uint16_t AdcG4<_Params...>::ReadSingle()
     {
         ConfigureAnalogPin<Pin>();
         return ReadSingle(ChannelNum<Pin>());
     }
 
-    ADCG4_TEMPLATE_ARGS
-    bool ADCG4_TEMPLATE_QUALIFIER::StartRegular(const uint8_t* channels, uint8_t channelsCount, uint16_t* dataBuffer, uint16_t scanCount)
+    template<typename... _Params>
+    bool AdcG4<_Params...>::StartRegular(const uint8_t* channels, uint8_t channelsCount, uint16_t* dataBuffer, uint16_t scanCount)
     {
         static_assert(!std::is_void_v<_DmaChannel>, "StartRegular requires a DMA channel");
 
@@ -427,8 +438,8 @@ namespace Zhele::Private
         return true;
     }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::StopRegular()
+    template<typename... _Params>
+    void AdcG4<_Params...>::StopRegular()
     {
         static_assert(!std::is_void_v<_DmaChannel>, "StopRegular requires a DMA channel");
 
@@ -441,23 +452,23 @@ namespace Zhele::Private
         _DmaChannel::Disable();
     }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::EnableVref() { _CommonRegs()->CCR |= ADC_CCR_VREFEN; }
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::DisableVref() { _CommonRegs()->CCR &= ~ADC_CCR_VREFEN; }
+    template<typename... _Params>
+    void AdcG4<_Params...>::EnableVref() { _CommonRegs()->CCR |= ADC_CCR_VREFEN; }
+    template<typename... _Params>
+    void AdcG4<_Params...>::DisableVref() { _CommonRegs()->CCR &= ~ADC_CCR_VREFEN; }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::EnableTemperatureSensor() { _CommonRegs()->CCR |= ADC_CCR_VSENSESEL; }
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::DisableTemperatureSensor() { _CommonRegs()->CCR &= ~ADC_CCR_VSENSESEL; }
+    template<typename... _Params>
+    void AdcG4<_Params...>::EnableTemperatureSensor() { _CommonRegs()->CCR |= ADC_CCR_VSENSESEL; }
+    template<typename... _Params>
+    void AdcG4<_Params...>::DisableTemperatureSensor() { _CommonRegs()->CCR &= ~ADC_CCR_VSENSESEL; }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::EnableVBat() { _CommonRegs()->CCR |= ADC_CCR_VBATSEL; }
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::DisableVBat() { _CommonRegs()->CCR &= ~ADC_CCR_VBATSEL; }
+    template<typename... _Params>
+    void AdcG4<_Params...>::EnableVBat() { _CommonRegs()->CCR |= ADC_CCR_VBATSEL; }
+    template<typename... _Params>
+    void AdcG4<_Params...>::DisableVBat() { _CommonRegs()->CCR &= ~ADC_CCR_VBATSEL; }
 
-    ADCG4_TEMPLATE_ARGS
-    uint16_t ADCG4_TEMPLATE_QUALIFIER::MeasureVdda()
+    template<typename... _Params>
+    uint16_t AdcG4<_Params...>::MeasureVdda()
     {
         EnableVref();
         delay_us<12>(); // tSTART, VREFINT
@@ -470,14 +481,14 @@ namespace Zhele::Private
         return _vddaMv;
     }
 
-    ADCG4_TEMPLATE_ARGS
-    unsigned ADCG4_TEMPLATE_QUALIFIER::ToVolts(uint16_t value)
+    template<typename... _Params>
+    unsigned AdcG4<_Params...>::ToVolts(uint16_t value)
     {
         return static_cast<unsigned>(value) * _vddaMv / ((1u << ResolutionBits) - 1);
     }
 
-    ADCG4_TEMPLATE_ARGS
-    int16_t ADCG4_TEMPLATE_QUALIFIER::ReadTemperature()
+    template<typename... _Params>
+    int16_t AdcG4<_Params...>::ReadTemperature()
     {
         EnableTemperatureSensor();
         delay_us<120>(); // tS_TEMPSENSOR (temperature sensor buffer stabilization time)
@@ -495,14 +506,12 @@ namespace Zhele::Private
             + Adc_TempSensorCal1Temp);
     }
 
-    ADCG4_TEMPLATE_ARGS
-    void ADCG4_TEMPLATE_QUALIFIER::IrqHandler()
+    template<typename... _Params>
+    void AdcG4<_Params...>::IrqHandler()
     {
         _Regs()->ISR = _Regs()->ISR;
     }
 
-    #undef ADCG4_TEMPLATE_ARGS
-    #undef ADCG4_TEMPLATE_QUALIFIER
 }
 
 #endif //! ZHELE_PLATFORM_STM32_G4_ADC_H

--- a/include/zhele/platform/stm32/g4/clock.h
+++ b/include/zhele/platform/stm32/g4/clock.h
@@ -1,0 +1,420 @@
+/**
+ * @file
+ * Implemets clocks for stm32g4 series
+ *
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_CLOCK_H
+#define ZHELE_PLATFORM_STM32_G4_CLOCK_H
+
+#include <stm32g4xx.h>
+
+#include "../common/clock.h"
+
+namespace Zhele::Clock
+{
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->PLLCFGR, PllM, RCC_PLLCFGR_PLLM);
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->PLLCFGR, PllN, RCC_PLLCFGR_PLLN);
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->PLLCFGR, PllP, RCC_PLLCFGR_PLLP);
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->PLLCFGR, PllPDiv, RCC_PLLCFGR_PLLPDIV);
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->PLLCFGR, PllQ, RCC_PLLCFGR_PLLQ);
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->PLLCFGR, PllR, RCC_PLLCFGR_PLLR);
+
+    inline unsigned PllClock::GetDivider()
+    {
+        return PllM::Get() + 1;
+    }
+
+    template<unsigned divider>
+    inline void PllClock::SetDivider()
+    {
+        static_assert(1 <= divider && divider <= (PllM::MaxValue + 1), "Invalid divider value!");
+        PllM::Set(divider - 1);
+    }
+
+    inline unsigned PllClock::GetMultipler()
+    {
+        return PllN::Get();
+    }
+
+    template<unsigned multiplier>
+    inline void PllClock::SetMultiplier()
+    {
+        static_assert(8 <= multiplier && multiplier <= 127, "Invalid multiplier value!");
+        PllN::Set(multiplier);
+    }
+
+    template<PllClock::ClockSource clockSource>
+    inline void PllClock::SelectClockSource()
+    {
+        RCC->PLLCFGR = (RCC->PLLCFGR & ~(RCC_PLLCFGR_PLLSRC_Msk))
+            | (clockSource == External
+                ? RCC_PLLCFGR_PLLSRC_HSE
+                : RCC_PLLCFGR_PLLSRC_HSI);
+    }
+
+    inline PllClock::ClockSource PllClock::GetClockSource()
+    {
+        return (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC_Msk) == RCC_PLLCFGR_PLLSRC_HSE
+            ? ClockSource::External
+            : ClockSource::Internal;
+    }
+
+    /**
+     * @brief System clock is taken from PLLR output (2/4/6/8)
+     */
+    inline unsigned PllClock::GetSystemOutputDivider()
+    {
+        return (PllR::Get() + 1) * 2;
+    }
+
+    template<unsigned divider>
+    inline void PllClock::SetSystemOutputDivider()
+    {
+        static_assert(divider == 2 || divider == 4 || divider == 6 || divider == 8, "Invalid divider value!");
+        RCC->PLLCFGR |= RCC_PLLCFGR_PLLREN;
+        PllR::Set(divider / 2 - 1);
+    }
+
+    /**
+     * @brief 48 MHz clock (USB, RNG, ...) is taken from PLLQ output (2/4/6/8)
+     */
+    inline unsigned PllClock::GetUsbOutputDivider()
+    {
+        return (PllQ::Get() + 1) * 2;
+    }
+
+    template<unsigned divider>
+    inline void PllClock::SetUsbOutputDivider()
+    {
+        static_assert(divider == 2 || divider == 4 || divider == 6 || divider == 8, "Invalid divider value!");
+        RCC->PLLCFGR |= RCC_PLLCFGR_PLLQEN;
+        PllQ::Set(divider / 2 - 1);
+    }
+
+    /**
+     * @brief ADC/SAI clock is taken from PLLP output (PLLPDIV = 2..31)
+     */
+    inline unsigned PllClock::GetI2SOutputDivider()
+    {
+        return PllPDiv::Get() != 0
+            ? PllPDiv::Get()
+            : (PllP::Get() != 0 ? 17 : 7);
+    }
+
+    template<unsigned divider>
+    inline void PllClock::SetI2SOutputDivider()
+    {
+        static_assert(2 <= divider && divider <= PllPDiv::MaxValue, "Invalid divider value!");
+        RCC->PLLCFGR |= RCC_PLLCFGR_PLLPEN;
+        PllPDiv::Set(divider);
+    }
+
+    IO_REG_WRAPPER(RCC->CRRCR, RccCrrcrReg, uint32_t);
+
+    /**
+     * @brief Implements HSI48 (RC 48 MHz) clock source (USB, RNG)
+     */
+    class Hsi48Clock : public ClockBase<RccCrrcrReg>
+    {
+        using Base = ClockBase<RccCrrcrReg>;
+    public:
+        static constexpr ClockFrequenceT SrcClockFreq()
+        {
+            return 48000000u;
+        }
+
+        static constexpr unsigned GetDivider() { return 1; }
+
+        static constexpr unsigned GetMultipler() { return 1; }
+
+        static constexpr ClockFrequenceT ClockFreq()
+        {
+            return SrcClockFreq();
+        }
+
+        static bool Enable()
+        {
+            return Base::EnableClockSource(RCC_CRRCR_HSI48ON, RCC_CRRCR_HSI48RDY);
+        }
+
+        static bool Disable()
+        {
+            return Base::DisableClockSource(RCC_CRRCR_HSI48ON, RCC_CRRCR_HSI48RDY);
+        }
+    };
+
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->CFGR, AhbPrescalerBitField, RCC_CFGR_HPRE);
+
+    class AhbClock : public BusClock<SysClock, AhbPrescalerBitField>
+    {
+        using Base = BusClock<SysClock, AhbPrescalerBitField>;
+    public:
+        // AHB prescaler values
+        enum Prescaler
+        {
+            Div1 = RCC_CFGR_HPRE_DIV1 >> AhbPrescalerBitFieldOffset, ///< No divide (prescaler = 1)
+            Div2 = RCC_CFGR_HPRE_DIV2 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 2
+            Div4 = RCC_CFGR_HPRE_DIV4 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 4
+            Div8 = RCC_CFGR_HPRE_DIV8 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 8
+            Div16 = RCC_CFGR_HPRE_DIV16 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 16
+            Div64 = RCC_CFGR_HPRE_DIV64 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 64
+            Div128 = RCC_CFGR_HPRE_DIV128 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 128
+            Div256 = RCC_CFGR_HPRE_DIV256 >> AhbPrescalerBitFieldOffset, ///< Prescaler = 256
+            Div512 = RCC_CFGR_HPRE_DIV512 >> AhbPrescalerBitFieldOffset ///< Prescaler = 512
+        };
+
+        static ClockFrequenceT ClockFreq()
+        {
+            static constexpr uint8_t clockPrescShift[] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+
+            ClockFrequenceT clock = SysClock::ClockFreq();
+            uint8_t shiftBits = clockPrescShift[AhbPrescalerBitField::Get()];
+            clock >>= shiftBits;
+            return clock;
+        }
+
+        template<Prescaler prescaler>
+        static void SetPrescaler()
+        {
+            Base::SetPrescaler(prescaler);
+        }
+    };
+
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->CFGR, Apb1PrescalerBitField, RCC_CFGR_PPRE1);
+
+    /**
+     * @brief Implements APB1 clock
+     */
+    class Apb1Clock : BusClock<AhbClock, Apb1PrescalerBitField>
+    {
+        using Base = BusClock<AhbClock, Apb1PrescalerBitField>;
+    public:
+        /**
+         * @brief APB1 clock prescalers
+         */
+        enum Prescaler
+        {
+            Div1 = RCC_CFGR_PPRE1_DIV1 >> Apb1PrescalerBitFieldOffset, ///< No divide (prescaler = 1)
+            Div2 = RCC_CFGR_PPRE1_DIV2 >> Apb1PrescalerBitFieldOffset, ///< Prescaler = 2
+            Div4 = RCC_CFGR_PPRE1_DIV4 >> Apb1PrescalerBitFieldOffset, ///< Prescaler = 4
+            Div8 = RCC_CFGR_PPRE1_DIV8 >> Apb1PrescalerBitFieldOffset, ///< Prescaler = 8
+            Div16 = RCC_CFGR_PPRE1_DIV16 >> Apb1PrescalerBitFieldOffset, ///< Prescaler = 16
+        };
+
+        static ClockFrequenceT ClockFreq()
+        {
+            static constexpr uint8_t clockPrescShift[] = {0, 0, 0, 0, 1, 2, 3, 4};
+
+            ClockFrequenceT clock = AhbClock::ClockFreq();
+            uint8_t shiftBits = clockPrescShift[Apb1PrescalerBitField::Get()];
+            clock >>= shiftBits;
+            return clock;
+        }
+
+        template<Prescaler prescaler>
+        static void SetPrescaler()
+        {
+            Base::SetPrescaler(prescaler);
+        }
+    };
+
+    DECLARE_IO_BITFIELD_WRAPPER(RCC->CFGR, Apb2PrescalerBitField, RCC_CFGR_PPRE2);
+
+    /**
+     * @brief Implements APB2 clock
+     */
+    class Apb2Clock : BusClock<AhbClock, Apb2PrescalerBitField>
+    {
+        using Base = BusClock<AhbClock, Apb2PrescalerBitField>;
+    public:
+        /**
+         * @brief APB2 clock prescalers
+         */
+        enum Prescaler
+        {
+            Div1 = RCC_CFGR_PPRE2_DIV1 >> Apb2PrescalerBitFieldOffset, ///< No divide (prescaler = 1)
+            Div2 = RCC_CFGR_PPRE2_DIV2 >> Apb2PrescalerBitFieldOffset, ///< Prescaler = 2
+            Div4 = RCC_CFGR_PPRE2_DIV4 >> Apb2PrescalerBitFieldOffset, ///< Prescaler = 4
+            Div8 = RCC_CFGR_PPRE2_DIV8 >> Apb2PrescalerBitFieldOffset, ///< Prescaler = 8
+            Div16 = RCC_CFGR_PPRE2_DIV16 >> Apb2PrescalerBitFieldOffset, ///< Prescaler = 16
+        };
+
+        static ClockFrequenceT ClockFreq()
+        {
+            static constexpr uint8_t clockPrescShift[] = {0, 0, 0, 0, 1, 2, 3, 4};
+
+            ClockFrequenceT clock = AhbClock::ClockFreq();
+            uint8_t shiftBits = clockPrescShift[Apb2PrescalerBitField::Get()];
+            clock >>= shiftBits;
+            return clock;
+        }
+
+        template<Prescaler prescaler>
+        static void SetPrescaler()
+        {
+            Base::SetPrescaler(prescaler);
+        }
+    };
+
+    IO_REG_WRAPPER(RCC->AHB1ENR, Ahb1ClockEnableReg, uint32_t);
+    IO_REG_WRAPPER(RCC->AHB2ENR, Ahb2ClockEnableReg, uint32_t);
+    IO_REG_WRAPPER(RCC->AHB3ENR, Ahb3ClockEnableReg, uint32_t);
+
+    IO_REG_WRAPPER(RCC->APB1ENR1, PeriphClockEnable11, uint32_t);
+    IO_REG_WRAPPER(RCC->APB1ENR2, PeriphClockEnable12, uint32_t);
+    IO_REG_WRAPPER(RCC->APB2ENR, PeriphClockEnable2, uint32_t);
+
+    IO_REG_WRAPPER(RCC->AHB1RSTR, Ahb1ResetReg, uint32_t);
+    IO_REG_WRAPPER(RCC->AHB2RSTR, Ahb2ResetReg, uint32_t);
+    IO_REG_WRAPPER(RCC->AHB3RSTR, Ahb3ResetReg, uint32_t);
+    IO_REG_WRAPPER(RCC->APB1RSTR1, Apb11ResetReg, uint32_t);
+    IO_REG_WRAPPER(RCC->APB1RSTR2, Apb12ResetReg, uint32_t);
+    IO_REG_WRAPPER(RCC->APB2RSTR, Apb2ResetReg, uint32_t);
+
+    // AHB1
+    using Dma1Clock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_DMA1EN, AhbClock>;
+    using Dma2Clock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_DMA2EN, AhbClock>;
+    using DmaMux1Clock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_DMAMUX1EN, AhbClock>;
+    using CordicClock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_CORDICEN, AhbClock>;
+    using FmacClock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_FMACEN, AhbClock>;
+    using FlashClock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_FLASHEN, AhbClock>;
+    using CrcClock = ClockControl<Ahb1ClockEnableReg, RCC_AHB1ENR_CRCEN, AhbClock>;
+
+    // AHB2
+    using PortaClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIOAEN, AhbClock>;
+    using PortbClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIOBEN, AhbClock>;
+    using PortcClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIOCEN, AhbClock>;
+    using PortdClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIODEN, AhbClock>;
+    using PorteClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIOEEN, AhbClock>;
+    using PortfClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIOFEN, AhbClock>;
+    using PortgClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_GPIOGEN, AhbClock>;
+    using Adc12Clock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_ADC12EN, AhbClock>;
+    using Dac1Clock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_DAC1EN, AhbClock>;
+    using DacClock = Dac1Clock;
+    using Dac3Clock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_DAC3EN, AhbClock>;
+    using RngClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_RNGEN, AhbClock>;
+#if defined (RCC_AHB2ENR_ADC345EN)
+    using Adc345Clock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_ADC345EN, AhbClock>;
+#endif
+#if defined (RCC_AHB2ENR_DAC2EN)
+    using Dac2Clock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_DAC2EN, AhbClock>;
+#endif
+#if defined (RCC_AHB2ENR_DAC4EN)
+    using Dac4Clock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_DAC4EN, AhbClock>;
+#endif
+#if defined (RCC_AHB2ENR_AESEN)
+    using AesClock = ClockControl<Ahb2ClockEnableReg, RCC_AHB2ENR_AESEN, AhbClock>;
+#endif
+
+    // AHB3
+#if defined (RCC_AHB3ENR_FMCEN)
+    using FmcClock = ClockControl<Ahb3ClockEnableReg, RCC_AHB3ENR_FMCEN, AhbClock>;
+#endif
+#if defined (RCC_AHB3ENR_QSPIEN)
+    using QspiClock = ClockControl<Ahb3ClockEnableReg, RCC_AHB3ENR_QSPIEN, AhbClock>;
+#endif
+
+    // APB1 (ENR1)
+    using Tim2Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_TIM2EN, Apb1Clock>;
+    using Tim3Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_TIM3EN, Apb1Clock>;
+    using Tim4Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_TIM4EN, Apb1Clock>;
+    using Tim6Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_TIM6EN, Apb1Clock>;
+    using Tim7Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_TIM7EN, Apb1Clock>;
+    using CrsClock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_CRSEN, Apb1Clock>;
+    using RtcClock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_RTCAPBEN, Apb1Clock>;
+    using WatchDogClock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_WWDGEN, Apb1Clock>;
+    using Spi2Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_SPI2EN, Apb1Clock>;
+    using Spi3Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_SPI3EN, Apb1Clock>;
+    using Usart2Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_USART2EN, Apb1Clock>;
+    using Usart3Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_USART3EN, Apb1Clock>;
+    using Uart4Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_UART4EN, Apb1Clock>;
+    using I2c1Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_I2C1EN, Apb1Clock>;
+    using I2c2Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_I2C2EN, Apb1Clock>;
+    using UsbClock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_USBEN, Apb1Clock>;
+    using FdCanClock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_FDCANEN, Apb1Clock>;
+    using PowerClock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_PWREN, Apb1Clock>;
+    using PwrClock = PowerClock;
+    using I2c3Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_I2C3EN, Apb1Clock>;
+    using LpTim1Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_LPTIM1EN, Apb1Clock>;
+#if defined (RCC_APB1ENR1_TIM5EN)
+    using Tim5Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_TIM5EN, Apb1Clock>;
+#endif
+#if defined (RCC_APB1ENR1_UART5EN)
+    using Uart5Clock = ClockControl<PeriphClockEnable11, RCC_APB1ENR1_UART5EN, Apb1Clock>;
+#endif
+
+    // APB1 (ENR2)
+    using LpUart1Clock = ClockControl<PeriphClockEnable12, RCC_APB1ENR2_LPUART1EN, Apb1Clock>;
+    using Ucpd1Clock = ClockControl<PeriphClockEnable12, RCC_APB1ENR2_UCPD1EN, Apb1Clock>;
+#if defined (RCC_APB1ENR2_I2C4EN)
+    using I2c4Clock = ClockControl<PeriphClockEnable12, RCC_APB1ENR2_I2C4EN, Apb1Clock>;
+#endif
+
+    // APB2
+    using SysCfgClock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_SYSCFGEN, Apb2Clock>;
+    using Tim1Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_TIM1EN, Apb2Clock>;
+    using Spi1Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_SPI1EN, Apb2Clock>;
+    using Tim8Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_TIM8EN, Apb2Clock>;
+    using Usart1Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_USART1EN, Apb2Clock>;
+    using Tim15Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_TIM15EN, Apb2Clock>;
+    using Tim16Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_TIM16EN, Apb2Clock>;
+    using Tim17Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_TIM17EN, Apb2Clock>;
+    using Sai1Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_SAI1EN, Apb2Clock>;
+#if defined (RCC_APB2ENR_SPI4EN)
+    using Spi4Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_SPI4EN, Apb2Clock>;
+#endif
+#if defined (RCC_APB2ENR_TIM20EN)
+    using Tim20Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_TIM20EN, Apb2Clock>;
+#endif
+#if defined (RCC_APB2ENR_HRTIM1EN)
+    using Hrtim1Clock = ClockControl<PeriphClockEnable2, RCC_APB2ENR_HRTIM1EN, Apb2Clock>;
+#endif
+
+    /**
+     * @brief Power control helpers (voltage scaling range 1 boost mode is required for SYSCLK > 150 MHz)
+     */
+    class Power
+    {
+    public:
+        /**
+         * @brief Enables range 1 boost mode (R1MODE = 0)
+         *
+         * @details
+         * Must be called before switching SYSCLK above 150 MHz.
+         *
+         * @par Returns
+         *  Nothing
+         */
+        static void EnableBoostMode()
+        {
+            PowerClock::Enable();
+            PWR->CR5 &= ~PWR_CR5_R1MODE;
+        }
+
+        /**
+         * @brief Disables boost mode (R1MODE = 1, range 1 normal mode)
+         *
+         * @par Returns
+         *  Nothing
+         */
+        static void DisableBoostMode()
+        {
+            PowerClock::Enable();
+            PWR->CR5 |= PWR_CR5_R1MODE;
+        }
+
+        /**
+         * @brief Returns true if boost mode is enabled
+         */
+        static bool IsBoostModeEnabled()
+        {
+            return (PWR->CR5 & PWR_CR5_R1MODE) == 0;
+        }
+    };
+} // namespace Zhele::Clock
+
+#endif //! ZHELE_PLATFORM_STM32_G4_CLOCK_H

--- a/include/zhele/platform/stm32/g4/dac.h
+++ b/include/zhele/platform/stm32/g4/dac.h
@@ -1,0 +1,16 @@
+/**
+ * @file
+ * Implement DAC for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_DAC_H
+#define ZHELE_PLATFORM_STM32_G4_DAC_H
+
+#include <stm32g4xx.h>
+#include "../common/dac.h"
+
+#endif //! ZHELE_PLATFORM_STM32_G4_DAC_H

--- a/include/zhele/platform/stm32/g4/delay.h
+++ b/include/zhele/platform/stm32/g4/delay.h
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * Implements delay for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_DELAY_H
+#define ZHELE_PLATFORM_STM32_G4_DELAY_H
+
+#if !defined (F_CPU)
+    #warning F_CPU not defined. Will be used F_CPU equals 16 MHz (HSI16).
+    #define F_CPU 16000000UL
+#endif
+
+namespace Zhele
+{
+    /**
+     * Copy from F1
+     */
+    const static unsigned DelayInitInstructionsCount = 14;
+    const static unsigned InstructionsPerCycle = 10;
+    template<unsigned long us, unsigned long CpuFreq = F_CPU>
+    void delay_us()
+    {
+        static const unsigned int loops = (CpuFreq / 1000000u * us - DelayInitInstructionsCount) / InstructionsPerCycle;
+        for (unsigned int i = 0; i < loops; ++i) {
+            __asm__ volatile ("nop");
+        }
+    }
+
+    template<unsigned long ms, unsigned long CpuFreq = F_CPU>
+    void delay_ms()
+    {
+        delay_us<ms * 1000, CpuFreq>();
+    }
+
+}
+#endif //! ZHELE_PLATFORM_STM32_G4_DELAY_H

--- a/include/zhele/platform/stm32/g4/dma.h
+++ b/include/zhele/platform/stm32/g4/dma.h
@@ -1,0 +1,98 @@
+/**
+ * @file
+ * Implement DMA protocol for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_DMA_H
+#define ZHELE_PLATFORM_STM32_G4_DMA_H
+
+#include <stm32g4xx.h>
+#include "../common/dma.h"
+
+namespace Zhele
+{
+    namespace Private
+    {
+        /**
+         * @brief DMA clock control which also enables DMAMUX clock (required for any DMA request on G4)
+         */
+        template<typename _DmaClock>
+        class DmaWithMuxClock : public _DmaClock
+        {
+        public:
+            static void Enable()
+            {
+                _DmaClock::Enable();
+                Clock::DmaMux1Clock::Enable();
+            }
+        };
+
+        IO_STRUCT_WRAPPER(DMA1, Dma1, DMA_TypeDef);
+        IO_STRUCT_WRAPPER(DMA1_Channel1, Dma1Channel1, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA1_Channel2, Dma1Channel2, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA1_Channel3, Dma1Channel3, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA1_Channel4, Dma1Channel4, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA1_Channel5, Dma1Channel5, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA1_Channel6, Dma1Channel6, DMA_Channel_TypeDef);
+    #if defined (DMA1_Channel7)
+        IO_STRUCT_WRAPPER(DMA1_Channel7, Dma1Channel7, DMA_Channel_TypeDef);
+    #endif
+    #if defined (DMA1_Channel8)
+        IO_STRUCT_WRAPPER(DMA1_Channel8, Dma1Channel8, DMA_Channel_TypeDef);
+    #endif
+
+        IO_STRUCT_WRAPPER(DMA2, Dma2, DMA_TypeDef);
+        IO_STRUCT_WRAPPER(DMA2_Channel1, Dma2Channel1, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA2_Channel2, Dma2Channel2, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA2_Channel3, Dma2Channel3, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA2_Channel4, Dma2Channel4, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA2_Channel5, Dma2Channel5, DMA_Channel_TypeDef);
+        IO_STRUCT_WRAPPER(DMA2_Channel6, Dma2Channel6, DMA_Channel_TypeDef);
+    #if defined (DMA2_Channel7)
+        IO_STRUCT_WRAPPER(DMA2_Channel7, Dma2Channel7, DMA_Channel_TypeDef);
+    #endif
+    #if defined (DMA2_Channel8)
+        IO_STRUCT_WRAPPER(DMA2_Channel8, Dma2Channel8, DMA_Channel_TypeDef);
+    #endif
+    }
+
+#if defined (DMA1_Channel8)
+    using Dma1 = DmaModule<Private::Dma1, Private::DmaWithMuxClock<Clock::Dma1Clock>, 8>;
+    using Dma2 = DmaModule<Private::Dma2, Private::DmaWithMuxClock<Clock::Dma2Clock>, 8>;
+#else
+    using Dma1 = DmaModule<Private::Dma1, Private::DmaWithMuxClock<Clock::Dma1Clock>, 6>;
+    using Dma2 = DmaModule<Private::Dma2, Private::DmaWithMuxClock<Clock::Dma2Clock>, 6>;
+#endif
+
+    using Dma1Channel1 = DmaChannel<Dma1, Private::Dma1Channel1, 1, DMA1_Channel1_IRQn>;
+    using Dma1Channel2 = DmaChannel<Dma1, Private::Dma1Channel2, 2, DMA1_Channel2_IRQn>;
+    using Dma1Channel3 = DmaChannel<Dma1, Private::Dma1Channel3, 3, DMA1_Channel3_IRQn>;
+    using Dma1Channel4 = DmaChannel<Dma1, Private::Dma1Channel4, 4, DMA1_Channel4_IRQn>;
+    using Dma1Channel5 = DmaChannel<Dma1, Private::Dma1Channel5, 5, DMA1_Channel5_IRQn>;
+    using Dma1Channel6 = DmaChannel<Dma1, Private::Dma1Channel6, 6, DMA1_Channel6_IRQn>;
+#if defined (DMA1_Channel7)
+    using Dma1Channel7 = DmaChannel<Dma1, Private::Dma1Channel7, 7, DMA1_Channel7_IRQn>;
+#endif
+#if defined (DMA1_Channel8)
+    using Dma1Channel8 = DmaChannel<Dma1, Private::Dma1Channel8, 8, DMA1_Channel8_IRQn>;
+#endif
+
+    using Dma2Channel1 = DmaChannel<Dma2, Private::Dma2Channel1, 1, DMA2_Channel1_IRQn>;
+    using Dma2Channel2 = DmaChannel<Dma2, Private::Dma2Channel2, 2, DMA2_Channel2_IRQn>;
+    using Dma2Channel3 = DmaChannel<Dma2, Private::Dma2Channel3, 3, DMA2_Channel3_IRQn>;
+    using Dma2Channel4 = DmaChannel<Dma2, Private::Dma2Channel4, 4, DMA2_Channel4_IRQn>;
+    using Dma2Channel5 = DmaChannel<Dma2, Private::Dma2Channel5, 5, DMA2_Channel5_IRQn>;
+    using Dma2Channel6 = DmaChannel<Dma2, Private::Dma2Channel6, 6, DMA2_Channel6_IRQn>;
+#if defined (DMA2_Channel7)
+    using Dma2Channel7 = DmaChannel<Dma2, Private::Dma2Channel7, 7, DMA2_Channel7_IRQn>;
+#endif
+#if defined (DMA2_Channel8)
+    using Dma2Channel8 = DmaChannel<Dma2, Private::Dma2Channel8, 8, DMA2_Channel8_IRQn>;
+#endif
+} // namespace Zhele
+
+#endif //! ZHELE_PLATFORM_STM32_G4_DMA_H

--- a/include/zhele/platform/stm32/g4/dmamux.h
+++ b/include/zhele/platform/stm32/g4/dmamux.h
@@ -1,0 +1,199 @@
+/**
+ * @file
+ * Implement DMAMUX module for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_DMAMUX_H
+#define ZHELE_PLATFORM_STM32_G4_DMAMUX_H
+
+#include <stm32g4xx.h>
+#include "../common/dmamux.h"
+
+namespace Zhele
+{
+    enum DmamuxSyncInput
+    {
+        Exti0 = 0,
+        Exti1 = 1,
+        Exti2 = 2,
+        Exti3 = 3,
+        Exti4 = 4,
+        Exti5 = 5,
+        Exti6 = 6,
+        Exti7 = 7,
+        Exti8 = 8,
+        Exti9 = 9,
+        Exti10 = 10,
+        Exti11 = 11,
+        Exti12 = 12,
+        Exti13 = 13,
+        Exti14 = 14,
+        Exti15 = 15,
+        DmamuxEvent0 = 16,
+        DmamuxEvent1 = 17,
+        DmamuxEvent2 = 18,
+        DmamuxEvent3 = 19,
+        Lptim1Out = 20,
+    };
+
+    /// DMAMUX request inputs (RM0440 Table "DMAMUX: assignment of multiplexer inputs to resources")
+    enum DmamuxRequestInput
+    {
+        Mem2Mem = 0,
+        Generator0 = 1,
+        Generator1 = 2,
+        Generator2 = 3,
+        Generator3 = 4,
+        Adc1 = 5,
+        Dac1Ch1 = 6,
+        Dac1Ch2 = 7,
+        Tim6Up = 8,
+        Tim7Up = 9,
+        Spi1Rx = 10,
+        Spi1Tx = 11,
+        Spi2Rx = 12,
+        Spi2Tx = 13,
+        Spi3Rx = 14,
+        Spi3Tx = 15,
+        I2c1Rx = 16,
+        I2c1Tx = 17,
+        I2c2Rx = 18,
+        I2c2Tx = 19,
+        I2c3Rx = 20,
+        I2c3Tx = 21,
+        I2c4Rx = 22,
+        I2c4Tx = 23,
+        Usart1Rx = 24,
+        Usart1Tx = 25,
+        Usart2Rx = 26,
+        Usart2Tx = 27,
+        Usart3Rx = 28,
+        Usart3Tx = 29,
+        Uart4Rx = 30,
+        Uart4Tx = 31,
+        Uart5Rx = 32,
+        Uart5Tx = 33,
+        Lpuart1Rx = 34,
+        Lpuart1Tx = 35,
+        Adc2 = 36,
+        Adc3 = 37,
+        Adc4 = 38,
+        Adc5 = 39,
+        Quadspi = 40,
+        Dac2Ch1 = 41,
+        Tim1Ch1 = 42,
+        Tim1Ch2 = 43,
+        Tim1Ch3 = 44,
+        Tim1Ch4 = 45,
+        Tim1Up = 46,
+        Tim1Trig = 47,
+        Tim1Com = 48,
+        Tim8Ch1 = 49,
+        Tim8Ch2 = 50,
+        Tim8Ch3 = 51,
+        Tim8Ch4 = 52,
+        Tim8Up = 53,
+        Tim8Trig = 54,
+        Tim8Com = 55,
+        Tim2Ch1 = 56,
+        Tim2Ch2 = 57,
+        Tim2Ch3 = 58,
+        Tim2Ch4 = 59,
+        Tim2Up = 60,
+        Tim3Ch1 = 61,
+        Tim3Ch2 = 62,
+        Tim3Ch3 = 63,
+        Tim3Ch4 = 64,
+        Tim3Up = 65,
+        Tim3Trig = 66,
+        Tim4Ch1 = 67,
+        Tim4Ch2 = 68,
+        Tim4Ch3 = 69,
+        Tim4Ch4 = 70,
+        Tim4Up = 71,
+        Tim5Ch1 = 72,
+        Tim5Ch2 = 73,
+        Tim5Ch3 = 74,
+        Tim5Ch4 = 75,
+        Tim5Up = 76,
+        Tim5Trig = 77,
+        Tim15Ch1 = 78,
+        Tim15Up = 79,
+        Tim15Trig = 80,
+        Tim15Com = 81,
+        Tim16Ch1 = 82,
+        Tim16Up = 83,
+        Tim17Ch1 = 84,
+        Tim17Up = 85,
+        Tim20Ch1 = 86,
+        Tim20Ch2 = 87,
+        Tim20Ch3 = 88,
+        Tim20Ch4 = 89,
+        Tim20Up = 90,
+        AesIn = 91,
+        AesOut = 92,
+        Tim20Trig = 93,
+        Tim20Com = 94,
+        Hrtim1Master = 95,
+        Hrtim1TimerA = 96,
+        Hrtim1TimerB = 97,
+        Hrtim1TimerC = 98,
+        Hrtim1TimerD = 99,
+        Hrtim1TimerE = 100,
+        Hrtim1TimerF = 101,
+        Dac3Ch1 = 102,
+        Dac3Ch2 = 103,
+        Dac4Ch1 = 104,
+        Dac4Ch2 = 105,
+        Spi4Rx = 106,
+        Spi4Tx = 107,
+        Sai1A = 108,
+        Sai1B = 109,
+        FmacRead = 110,
+        FmacWrite = 111,
+        CordicRead = 112,
+        CordicWrite = 113,
+        Ucpd1Rx = 114,
+        Ucpd1Tx = 115,
+    };
+
+    namespace Private
+    {
+        IO_STRUCT_WRAPPER(DMAMUX1, Dmamux1, DMAMUX_Channel_TypeDef);
+    }
+
+    using DmaMux1 = DmaMux<Private::Dmamux1, DmamuxSyncInput, DmamuxRequestInput>;
+
+    // DMAMUX channels 0..7 are wired to DMA1 channels 1..8, channels 8..15 to DMA2 channels 1..8
+    // (on devices with 6 DMA channels per controller mux channels 6, 7, 14, 15 are not used)
+    using DmaMux1Channel1 = DmaMux1::Channel<0>;
+    using DmaMux1Channel2 = DmaMux1::Channel<1>;
+    using DmaMux1Channel3 = DmaMux1::Channel<2>;
+    using DmaMux1Channel4 = DmaMux1::Channel<3>;
+    using DmaMux1Channel5 = DmaMux1::Channel<4>;
+    using DmaMux1Channel6 = DmaMux1::Channel<5>;
+#if defined (DMA1_Channel7)
+    using DmaMux1Channel7 = DmaMux1::Channel<6>;
+#endif
+#if defined (DMA1_Channel8)
+    using DmaMux1Channel8 = DmaMux1::Channel<7>;
+#endif
+    using DmaMux2Channel1 = DmaMux1::Channel<8>;
+    using DmaMux2Channel2 = DmaMux1::Channel<9>;
+    using DmaMux2Channel3 = DmaMux1::Channel<10>;
+    using DmaMux2Channel4 = DmaMux1::Channel<11>;
+    using DmaMux2Channel5 = DmaMux1::Channel<12>;
+    using DmaMux2Channel6 = DmaMux1::Channel<13>;
+#if defined (DMA2_Channel7)
+    using DmaMux2Channel7 = DmaMux1::Channel<14>;
+#endif
+#if defined (DMA2_Channel8)
+    using DmaMux2Channel8 = DmaMux1::Channel<15>;
+#endif
+} // namespace Zhele
+
+#endif //! ZHELE_PLATFORM_STM32_G4_DMAMUX_H

--- a/include/zhele/platform/stm32/g4/dmamux.h
+++ b/include/zhele/platform/stm32/g4/dmamux.h
@@ -15,24 +15,27 @@
 
 namespace Zhele
 {
+    // Enumerator names are prefixed (SyncExtiN, not ExtiN) because DmamuxSyncInput is an
+    // unscoped enum in namespace Zhele (required by DmaMux's std::convertible_to<uint32_t>
+    // constraint) and would otherwise collide with the Exti0..Exti15 class aliases in exti.h.
     enum DmamuxSyncInput
     {
-        Exti0 = 0,
-        Exti1 = 1,
-        Exti2 = 2,
-        Exti3 = 3,
-        Exti4 = 4,
-        Exti5 = 5,
-        Exti6 = 6,
-        Exti7 = 7,
-        Exti8 = 8,
-        Exti9 = 9,
-        Exti10 = 10,
-        Exti11 = 11,
-        Exti12 = 12,
-        Exti13 = 13,
-        Exti14 = 14,
-        Exti15 = 15,
+        SyncExti0 = 0,
+        SyncExti1 = 1,
+        SyncExti2 = 2,
+        SyncExti3 = 3,
+        SyncExti4 = 4,
+        SyncExti5 = 5,
+        SyncExti6 = 6,
+        SyncExti7 = 7,
+        SyncExti8 = 8,
+        SyncExti9 = 9,
+        SyncExti10 = 10,
+        SyncExti11 = 11,
+        SyncExti12 = 12,
+        SyncExti13 = 13,
+        SyncExti14 = 14,
+        SyncExti15 = 15,
         DmamuxEvent0 = 16,
         DmamuxEvent1 = 17,
         DmamuxEvent2 = 18,
@@ -40,6 +43,8 @@ namespace Zhele
         Lptim1Out = 20,
     };
 
+    // Adc1..Adc5 are prefixed (AdcReqN, not AdcN) to avoid colliding with the Adc1..Adc5
+    // class template aliases in adc.h (same unscoped-enum issue as DmamuxSyncInput above).
     /// DMAMUX request inputs (RM0440 Table "DMAMUX: assignment of multiplexer inputs to resources")
     enum DmamuxRequestInput
     {
@@ -48,7 +53,7 @@ namespace Zhele
         Generator1 = 2,
         Generator2 = 3,
         Generator3 = 4,
-        Adc1 = 5,
+        AdcReq1 = 5,
         Dac1Ch1 = 6,
         Dac1Ch2 = 7,
         Tim6Up = 8,
@@ -79,10 +84,10 @@ namespace Zhele
         Uart5Tx = 33,
         Lpuart1Rx = 34,
         Lpuart1Tx = 35,
-        Adc2 = 36,
-        Adc3 = 37,
-        Adc4 = 38,
-        Adc5 = 39,
+        AdcReq2 = 36,
+        AdcReq3 = 37,
+        AdcReq4 = 38,
+        AdcReq5 = 39,
         Quadspi = 40,
         Dac2Ch1 = 41,
         Tim1Ch1 = 42,

--- a/include/zhele/platform/stm32/g4/exti.h
+++ b/include/zhele/platform/stm32/g4/exti.h
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * Implements EXTI for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_EXTI_H
+#define ZHELE_PLATFORM_STM32_G4_EXTI_H
+
+#include <stm32g4xx.h>
+
+// For compatibility with "default" CMSIS (F0/F1/F4)
+#define RTSR RTSR1
+#define FTSR FTSR1
+#define IMR IMR1
+#define PR PR1
+
+#include "../common/exti.h"
+
+namespace Zhele
+{
+    template<uint8_t _Line, IRQn_Type _IRQn>
+    template <typename port>
+    void Exti<_Line, _IRQn>::SelectPort()
+    {
+        SYSCFG->EXTICR[_Line / 4] = (SYSCFG->EXTICR[_Line / 4] & ~(0xF << (_Line % 4 * 4))) | ((port::Id - 'A') << (_Line % 4 * 4));
+    }
+
+    template<uint8_t _Line, IRQn_Type _IRQn>
+    void Exti<_Line, _IRQn>::SelectPort(uint8_t portID)
+    {
+        SYSCFG->EXTICR[_Line / 4] = (SYSCFG->EXTICR[_Line / 4] & ~(0xF << (_Line % 4 * 4))) | ((portID - 'A') << (_Line % 4 * 4));
+    }
+
+    template<uint8_t _Line, IRQn_Type _IRQn>
+    void Exti<_Line, _IRQn>::EnableClock()
+    {
+        Clock::SysCfgClock::Enable();
+    }
+
+    using Exti0 = Exti<0, EXTI0_IRQn>;
+    using Exti1 = Exti<1, EXTI1_IRQn>;
+    using Exti2 = Exti<2, EXTI2_IRQn>;
+    using Exti3 = Exti<3, EXTI3_IRQn>;
+    using Exti4 = Exti<4, EXTI4_IRQn>;
+
+    using Exti5 = Exti<5, EXTI9_5_IRQn>;
+    using Exti6 = Exti<6, EXTI9_5_IRQn>;
+    using Exti7 = Exti<7, EXTI9_5_IRQn>;
+    using Exti8 = Exti<8, EXTI9_5_IRQn>;
+    using Exti9 = Exti<9, EXTI9_5_IRQn>;
+
+    using Exti10 = Exti<10, EXTI15_10_IRQn>;
+    using Exti11 = Exti<11, EXTI15_10_IRQn>;
+    using Exti12 = Exti<12, EXTI15_10_IRQn>;
+    using Exti13 = Exti<13, EXTI15_10_IRQn>;
+    using Exti14 = Exti<14, EXTI15_10_IRQn>;
+    using Exti15 = Exti<15, EXTI15_10_IRQn>;
+}
+#endif //! ZHELE_PLATFORM_STM32_G4_EXTI_H

--- a/include/zhele/platform/stm32/g4/flash.h
+++ b/include/zhele/platform/stm32/g4/flash.h
@@ -1,0 +1,208 @@
+/**
+ * @file
+ * Implements FLASH for stm32g4 series
+ *
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_FLASH_H
+#define ZHELE_PLATFORM_STM32_G4_FLASH_H
+
+#include <stm32g4xx.h>
+
+// G4 CMSIS does not define FLASH_SIZE, so (like HAL does) read it from the flash size register.
+// Define FLASH_SIZE explicitly to override.
+#if !defined (FLASH_SIZE)
+    #define FLASH_SIZE (((*reinterpret_cast<const volatile uint16_t*>(FLASHSIZE_BASE)) == 0xFFFFU) \
+        ? 0x80000U \
+        : (static_cast<uint32_t>(*reinterpret_cast<const volatile uint16_t*>(FLASHSIZE_BASE)) << 10U))
+#endif
+
+#include "../common/flash.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace Zhele
+{
+    /**
+     * @brief Configures flash latency (and range 1 boost mode) for target system frequency
+     *
+     * @details
+     * Wait states are calculated for voltage range 1 (normal mode: 30 MHz per WS, up to 150 MHz).
+     * Above 150 MHz boost mode is enabled and 4 WS are used (up to 170 MHz).
+     * Note: RM0440 recommends AHB prescaler = 2 while switching to a frequency above 150 MHz
+     * and restoring it after 1 us. This is not done automatically.
+     */
+    inline void Flash::ConfigureFrequence(uint32_t frequence)
+    {
+        uint32_t ws;
+        if (frequence > 150000000u)
+        {
+            RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
+            PWR->CR5 &= ~PWR_CR5_R1MODE;
+            ws = 4;
+        }
+        else
+        {
+            ws = (frequence - 1) / 30000000u;
+            if (ws > 4)
+                ws = 4;
+        }
+
+        FLASH->ACR = (FLASH->ACR & ~FLASH_ACR_LATENCY)
+            | (ws << FLASH_ACR_LATENCY_Pos)
+            | FLASH_ACR_PRFTEN | FLASH_ACR_ICEN | FLASH_ACR_DCEN;
+
+        while ((FLASH->ACR & FLASH_ACR_LATENCY) != (ws << FLASH_ACR_LATENCY_Pos)) continue;
+    }
+
+    /**
+     * @brief Returns page size
+     *
+     * @details
+     * Category 2 devices (G431/G441) have 2 KB pages.
+     * Category 3/4 devices (G47x/G48x/G49x) have 2 KB pages in dual bank mode (DBANK = 1, default)
+     * and 4 KB pages in single bank mode. Single bank mode is not supported.
+     */
+    inline constexpr uint32_t Flash::PageSize(unsigned)
+    {
+        return 2048;
+    }
+
+    inline constexpr uint32_t Flash::PageCount()
+    {
+        return FlashSize() / PageSize(0);
+    }
+
+    inline constexpr unsigned Flash::AddressToPage(const void* address)
+    {
+        uint32_t offset = reinterpret_cast<uint32_t>(address) - FLASH_BASE;
+
+        return offset / PageSize(0);
+    }
+
+    inline bool Flash::ErasePage(uint32_t page)
+    {
+        if (page >= PageCount())
+            return false;
+
+        if (IsLock())
+            Unlock();
+
+        WaitWhileBusy();
+
+        FLASH->SR = FLASH_SR_EOP | FLASH_SR_OPERR | FLASH_SR_PROGERR | FLASH_SR_WRPERR
+            | FLASH_SR_PGAERR | FLASH_SR_SIZERR | FLASH_SR_PGSERR | FLASH_SR_MISERR | FLASH_SR_FASTERR;
+
+        uint32_t cr = FLASH_CR_PER | FLASH_CR_EOPIE;
+#if defined (FLASH_CR_BKER)
+        // Dual bank devices: pages of the second bank are addressed relative to it
+        constexpr uint32_t pagesPerBank = 128;
+        if (page >= pagesPerBank)
+        {
+            cr |= FLASH_CR_BKER;
+            page -= pagesPerBank;
+        }
+#endif
+        FLASH->CR |= cr | (page << FLASH_CR_PNB_Pos);
+        FLASH->CR |= FLASH_CR_STRT;
+
+        __asm("nop"); // The software should start checking if the BSY bit equals “0” at least one CPU cycle after setting the STRT bit.
+
+        WaitWhileBusy();
+
+        uint32_t clearMask = FLASH_CR_PER | FLASH_CR_EOPIE | FLASH_CR_PNB_Msk;
+#if defined (FLASH_CR_BKER)
+        clearMask |= FLASH_CR_BKER;
+#endif
+
+        if ((FLASH->SR & FLASH_SR_EOP) == 0) {
+            FLASH->CR &= ~clearMask;
+            return false;
+        }
+
+        FLASH->CR &= ~clearMask;
+        FLASH->SR = FLASH_SR_EOP;
+
+        return true;
+    }
+
+    inline bool Flash::WriteFlash(void* dst, const void* src, unsigned size)
+    {
+        if (IsLock())
+            Unlock();
+
+        const uint32_t* aligned_src = reinterpret_cast<const uint32_t*>(src);
+        uint32_t* aligned_dst = reinterpret_cast<uint32_t*>(dst);
+
+        FLASH->SR = FLASH_SR_EOP | FLASH_SR_OPERR | FLASH_SR_PROGERR | FLASH_SR_WRPERR
+            | FLASH_SR_PGAERR | FLASH_SR_SIZERR | FLASH_SR_PGSERR | FLASH_SR_MISERR | FLASH_SR_FASTERR;
+
+        FLASH->CR |= FLASH_CR_PG | FLASH_CR_EOPIE;
+
+        if ((reinterpret_cast<uint32_t>(aligned_src) & 0x3) == 0) {
+            while (size >= (2 * sizeof(uint32_t))) {
+                *aligned_dst++ = *aligned_src++;
+                *aligned_dst++ = *aligned_src++;
+                size -= (2 * sizeof(uint32_t));
+                WaitWhileBusy();
+
+                if ((FLASH->SR & FLASH_SR_EOP) == 0)
+                    return false;
+
+                FLASH->SR = FLASH_SR_EOP;
+            }
+        } else {
+            alignas(2 * sizeof(uint32_t)) volatile uint32_t buffer[2];
+            while (size >= (2 * sizeof(uint32_t))) {
+                for(int i = 0; i < 8; ++i) {
+                    reinterpret_cast<volatile uint8_t*>(&buffer[0])[i] = reinterpret_cast<const uint8_t*>(aligned_src)[i];
+                }
+
+                *aligned_dst++ = buffer[0];
+                *aligned_dst++ = buffer[1];
+                aligned_src += 2;
+
+                size -= (2 * sizeof(uint32_t));
+                WaitWhileBusy();
+
+                if ((FLASH->SR & FLASH_SR_EOP) == 0) {
+                    return false;
+                }
+
+                FLASH->SR = FLASH_SR_EOP;
+            }
+        }
+
+        if (size > 0) {
+            alignas(2 * sizeof(uint32_t)) uint32_t buffer[2];
+
+            for(unsigned i = 0; i < size; ++i) {
+                reinterpret_cast<volatile uint8_t*>(&buffer[0])[i] = reinterpret_cast<const uint8_t*>(aligned_src)[i];
+            }
+            for(unsigned i = 0; i < sizeof(buffer) - size; ++i) {
+                reinterpret_cast<volatile uint8_t*>(&buffer[0])[size + i] = reinterpret_cast<const uint8_t*>(aligned_dst)[i];
+            }
+
+            *aligned_dst++ = buffer[0];
+            *aligned_dst++ = buffer[1];
+            WaitWhileBusy();
+
+            if ((FLASH->SR & FLASH_SR_EOP) == 0) {
+                return false;
+            }
+
+            FLASH->SR = FLASH_SR_EOP;
+        }
+
+        FLASH->CR &= ~(FLASH_CR_PG | FLASH_CR_EOPIE);
+        Lock();
+
+        return ((FLASH->SR & (FLASH_SR_WRPERR | FLASH_SR_PROGERR)) == 0);
+    }
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_FLASH_H

--- a/include/zhele/platform/stm32/g4/i2c.h
+++ b/include/zhele/platform/stm32/g4/i2c.h
@@ -1,0 +1,158 @@
+/**
+ * @file
+ * Implement i2c protocol for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_I2C_H
+#define ZHELE_PLATFORM_STM32_G4_I2C_H
+
+#include "../common/i2c.h"
+
+#include "dma.h"
+#include "iopins.h"
+
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+namespace Zhele
+{
+    namespace Private
+    {
+        I2C_TEMPLATE_ARGS
+        template<unsigned sclPinNumber, unsigned sdaPinNumber>
+        void I2C_TEMPLATE_QUALIFIER::SelectPins()
+        {
+            using SclPin = typename _SclPins::io_pins::template Pin<sclPinNumber>;
+            SclPin::Port::Enable();
+            SclPin::template SetConfiguration<SclPin::Port::Configuration::AltFunc>();
+            SclPin::template AltFuncNumber<_SclPins::alt_functions[sclPinNumber]>();
+            SclPin::SetDriverType(SclPin::Port::DriverType::OpenDrain);
+            SclPin::SetPullMode(SclPin::PullMode::PullUp);
+
+            using SdaPin = typename _SdaPins::io_pins::template Pin<sdaPinNumber>;
+            if constexpr (!std::is_same_v<typename SdaPin::Port, typename SclPin::Port>)
+            {
+                SdaPin::Port::Enable();
+            }
+            SdaPin::template SetConfiguration<SdaPin::Port::Configuration::AltFunc>();
+            SdaPin::template AltFuncNumber<_SdaPins::alt_functions[sdaPinNumber]>();
+            SdaPin::SetDriverType(SdaPin::Port::DriverType::OpenDrain);
+            SdaPin::SetPullMode(SdaPin::PullMode::PullUp);
+        }
+
+        I2C_TEMPLATE_ARGS
+        void I2C_TEMPLATE_QUALIFIER::SelectPins(uint8_t sclPinNumber, uint8_t sdaPinNumber)
+        {
+            using SclPins = typename _SclPins::io_pins;
+            using SdaPins = typename _SdaPins::io_pins;
+
+            using Type = typename SclPins::DataType;
+
+            SclPins::Enable();
+            Type maskScl(1 << sclPinNumber);
+            SclPins::SetConfiguration(SclPins::Configuration::AltFunc, maskScl);
+            SclPins::AltFuncNumber(_SclPins::alt_functions[sclPinNumber], maskScl);
+            SclPins::SetDriverType(SclPins::DriverType::OpenDrain, maskScl);
+            SclPins::SetPullMode(SclPins::PullMode::PullUp, maskScl);
+
+            SdaPins::Enable();
+            Type maskSda(1 << sdaPinNumber);
+            SdaPins::SetConfiguration(SdaPins::Configuration::AltFunc, maskSda);
+            SdaPins::AltFuncNumber(_SdaPins::alt_functions[sdaPinNumber], maskSda);
+            SdaPins::SetDriverType(SdaPins::DriverType::OpenDrain, maskSda);
+            SdaPins::SetPullMode(SdaPins::PullMode::PullUp, maskSda);
+        }
+        
+        I2C_TEMPLATE_ARGS
+        template<typename SclPin, typename SdaPin>
+        void I2C_TEMPLATE_QUALIFIER::SelectPins()
+        {
+            const int sclPinIndex = _SclPins::io_pins:: template IndexOf<SclPin>;
+            const int sdaPinIndex = _SdaPins::io_pins:: template IndexOf<SdaPin>;
+            
+            static_assert(sclPinIndex >= 0);
+            static_assert(sdaPinIndex >= 0);
+
+            SelectPins<sclPinIndex, sdaPinIndex>();
+        }
+
+        struct I2c1SclPins
+        {
+            using io_pins = IO::PinList<IO::Pa13, IO::Pa15>;
+            static constexpr std::array<uint8_t, 2> alt_functions{4, 4};
+        };
+        struct I2c1SdaPins
+        {
+            using io_pins = IO::PinList<IO::Pa14, IO::Pb7, IO::Pb9>;
+            static constexpr std::array<uint8_t, 3> alt_functions{4, 4, 4};
+        };
+
+        struct I2c2SclPins
+        {
+            using io_pins = IO::PinList<IO::Pa9, IO::Pc4>;
+            static constexpr std::array<uint8_t, 2> alt_functions{4, 4};
+        };
+        struct I2c2SdaPins
+        {
+            using io_pins = IO::PinList<IO::Pa8>;
+            static constexpr std::array<uint8_t, 1> alt_functions{4};
+        };
+
+        struct I2c3SclPins
+        {
+            using io_pins = IO::PinList<IO::Pa8, IO::Pc8>;
+            static constexpr std::array<uint8_t, 2> alt_functions{2, 8};
+        };
+        struct I2c3SdaPins
+        {
+            using io_pins = IO::PinList<IO::Pb5, IO::Pc9, IO::Pc11>;
+            static constexpr std::array<uint8_t, 3> alt_functions{8, 8, 8};
+        };
+
+#if defined (I2C4)
+        struct I2c4SclPins
+        {
+            using io_pins = IO::PinList<IO::Pa13, IO::Pc6>;
+            static constexpr std::array<uint8_t, 2> alt_functions{3, 8};
+        };
+        struct I2c4SdaPins
+        {
+            using io_pins = IO::PinList<IO::Pb7, IO::Pc7>;
+            static constexpr std::array<uint8_t, 2> alt_functions{3, 8};
+        };
+#endif
+
+        IO_STRUCT_WRAPPER(I2C1, I2c1Regs, I2C_TypeDef);
+        IO_STRUCT_WRAPPER(I2C2, I2c2Regs, I2C_TypeDef);
+        IO_STRUCT_WRAPPER(I2C3, I2c3Regs, I2C_TypeDef);
+#if defined (I2C4)
+        IO_STRUCT_WRAPPER(I2C4, I2c4Regs, I2C_TypeDef);
+#endif
+    }
+
+    // DMAMUX request inputs: I2c1Rx/Tx = 16/17, I2c2Rx/Tx = 18/19, I2c3Rx/Tx = 20/21, I2c4Rx/Tx = 22/23 (see dmamux.h)
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using I2c1 = Private::I2cBase<Private::I2c1Regs, I2C1_EV_IRQn, I2C1_ER_IRQn, Clock::I2c1Clock, Private::I2c1SclPins, Private::I2c1SdaPins, _DmaTx, _DmaRx>;
+    using I2c1NoDma = I2c1<>;
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using I2c2 = Private::I2cBase<Private::I2c2Regs, I2C2_EV_IRQn, I2C2_ER_IRQn, Clock::I2c2Clock, Private::I2c2SclPins, Private::I2c2SdaPins, _DmaTx, _DmaRx>;
+    using I2c2NoDma = I2c2<>;
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using I2c3 = Private::I2cBase<Private::I2c3Regs, I2C3_EV_IRQn, I2C3_ER_IRQn, Clock::I2c3Clock, Private::I2c3SclPins, Private::I2c3SdaPins, _DmaTx, _DmaRx>;
+    using I2c3NoDma = I2c3<>;
+
+#if defined (I2C4)
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using I2c4 = Private::I2cBase<Private::I2c4Regs, I2C4_EV_IRQn, I2C4_ER_IRQn, Clock::I2c4Clock, Private::I2c4SclPins, Private::I2c4SdaPins, _DmaTx, _DmaRx>;
+    using I2c4NoDma = I2c4<>;
+#endif
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_I2C_H

--- a/include/zhele/platform/stm32/g4/iopins.h
+++ b/include/zhele/platform/stm32/g4/iopins.h
@@ -1,0 +1,18 @@
+/**
+ * @file
+ * Contains instances of gpio pins (as typedefs) for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_IOPINS_H
+#define ZHELE_PLATFORM_STM32_G4_IOPINS_H
+#include <stm32g4xx.h>
+
+#include "ioports.h"
+
+#include "../common/iopins.h"
+
+#endif //! ZHELE_PLATFORM_STM32_G4_IOPINS_H

--- a/include/zhele/platform/stm32/g4/ioports.h
+++ b/include/zhele/platform/stm32/g4/ioports.h
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * Implement GPIO port for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_IOPORTS_H
+#define ZHELE_PLATFORM_STM32_G4_IOPORTS_H
+
+#include <stm32g4xx.h>
+
+#include "clock.h"
+#include "../common/ioports.h"
+
+
+#endif //! ZHELE_PLATFORM_STM32_G4_IOPORTS_H

--- a/include/zhele/platform/stm32/g4/pinlist.h
+++ b/include/zhele/platform/stm32/g4/pinlist.h
@@ -1,0 +1,17 @@
+ /**
+ * @file
+ * Contains class for pins list (~virtual port)
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @licence MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_PINLIST_H
+#define ZHELE_PLATFORM_STM32_G4_PINLIST_H
+
+#include <stm32g4xx.h>
+
+#include "../common/pinlist.h"
+
+#endif //! ZHELE_PLATFORM_STM32_G4_PINLIST_H

--- a/include/zhele/platform/stm32/g4/rng.h
+++ b/include/zhele/platform/stm32/g4/rng.h
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Implements RNG for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_RNG_H
+#define ZHELE_PLATFORM_STM32_G4_RNG_H
+
+#include <stm32g4xx.h>
+
+#if defined (RNG)
+    // RNG kernel clock (RCC_CCIPR_CLK48SEL) resets to HSI48: enable it before Rng::Init()
+    // (Zhele::Clock::Hsi48Clock::Enable(), see clock.h) or select another 48 MHz source.
+    #include "../common/rng.h"
+#else
+    #error "THIS MCU does not support hardware RNG"
+#endif
+
+#endif //! ZHELE_PLATFORM_STM32_G4_RNG_H

--- a/include/zhele/platform/stm32/g4/spi.h
+++ b/include/zhele/platform/stm32/g4/spi.h
@@ -1,0 +1,275 @@
+/**
+ * @file
+ * Implements SPI protocol for stm32g4 series
+ * 
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @licence MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G0_SPI_H
+#define ZHELE_PLATFORM_STM32_G0_SPI_H
+
+#include "../common/spi.h"
+
+#include "dma.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace Zhele
+{
+    namespace Private
+    {
+        template<typename _Regs, typename _Clock, typename _MosiPins, typename _MisoPins, typename _ClockPins, typename _SsPins, typename _DmaTx, typename _DmaRx>
+        void Spi<_Regs, _Clock, _MosiPins, _MisoPins, _ClockPins, _SsPins, _DmaTx, _DmaRx>::SelectPins(int8_t mosiPinNumber, int8_t misoPinNumber, int8_t clockPinNumber, int8_t ssPinNumber)
+        {
+            using MosiPins = typename _MosiPins::io_pins;
+            using MisoPins = typename _MisoPins::io_pins;
+            using ClockPins = typename _ClockPins::io_pins;
+            using SsPins = typename _SsPins::io_pins;
+
+            using Type = typename MosiPins::DataType;
+
+            if(mosiPinNumber != -1)
+            {
+                MosiPins::Enable();
+                Type maskMosi(1 << mosiPinNumber);
+                MosiPins::SetConfiguration(MosiPins::Configuration::AltFunc, maskMosi);
+                MosiPins::SetDriverType(MosiPins::DriverType::PushPull, maskMosi);
+                MosiPins::AltFuncNumber(_MosiPins::alt_functions[static_cast<size_t>(mosiPinNumber)], maskMosi);
+            }
+
+            if(misoPinNumber != -1)
+            {
+                MisoPins::Enable();
+                Type maskMiso(1 << misoPinNumber);
+                MisoPins::SetConfiguration(MisoPins::Configuration::In, maskMiso);
+                MisoPins::AltFuncNumber(_MisoPins::alt_functions[static_cast<size_t>(misoPinNumber)], maskMiso);
+            }
+
+            ClockPins::Enable();
+            Type maskClock(1 << clockPinNumber);
+            ClockPins::SetConfiguration(ClockPins::Configuration::AltFunc, maskClock);
+            ClockPins::SetDriverType(ClockPins::DriverType::PushPull, maskClock);
+            ClockPins::AltFuncNumber(_ClockPins::alt_functions[static_cast<size_t>(clockPinNumber)], maskClock);
+            
+            if(ssPinNumber != -1)
+            {
+                SsPins::Enable();
+                Type maskSs(1 << ssPinNumber);
+                SsPins::SetConfiguration(SsPins::Configuration::AltFunc, maskSs);
+                SsPins::SetDriverType(SsPins::DriverType::PushPull, maskSs);
+                SsPins::AltFuncNumber(_SsPins::alt_functions[static_cast<size_t>(ssPinNumber)], maskSs);
+            }
+        }
+
+        template<typename _Regs, typename _Clock, typename _MosiPins, typename _MisoPins, typename _ClockPins, typename _SsPins, typename _DmaTx, typename _DmaRx>
+        template<int8_t mosiPinNumber, int8_t misoPinNumber, int8_t clockPinNumber, int8_t ssPinNumber>
+        void Spi<_Regs, _Clock, _MosiPins, _MisoPins, _ClockPins, _SsPins, _DmaTx, _DmaRx>::SelectPins()
+        {
+            using MosiPin = std::conditional_t<mosiPinNumber != -1, typename _MosiPins::io_pins::template Pin<mosiPinNumber>, typename IO::NullPin>;
+            using MisoPin = std::conditional_t<misoPinNumber != -1, typename _MisoPins::io_pins::template Pin<misoPinNumber>, typename IO::NullPin>;
+            using ClockPin = typename _ClockPins::io_pins::template Pin<clockPinNumber>;
+            using SsPin = std::conditional_t<ssPinNumber != -1, typename _SsPins::io_pins::template Pin<ssPinNumber>, typename IO::NullPin>;
+
+            constexpr auto usedPorts = template_utils::type_list<typename MosiPin::Port, typename MisoPin::Port, typename ClockPin::Port, typename SsPin::Port>::remove_duplicates();
+            usedPorts.foreach([](auto port) { port.Enable(); });
+
+            if constexpr(mosiPinNumber != -1)
+            {
+                MosiPin::template SetConfiguration<MosiPin::Port::Configuration::AltFunc>();
+                MosiPin::template SetDriverType<MosiPin::DriverType::PushPull>();
+                MosiPin::template AltFuncNumber<_MosiPins::alt_functions[mosiPinNumber]>();
+            }
+
+            if constexpr(misoPinNumber != -1)
+            {
+                MisoPin::template SetConfiguration<MisoPin::Port::Configuration::AltFunc>();
+                MisoPin::template AltFuncNumber<_MisoPins::alt_functions[misoPinNumber]>();
+            }
+
+            ClockPin::template SetConfiguration<ClockPin::Port::Configuration::AltFunc>();
+            ClockPin::template SetDriverType<ClockPin::DriverType::PushPull>();
+            ClockPin::template AltFuncNumber<_ClockPins::alt_functions[clockPinNumber]>();
+
+            if constexpr(ssPinNumber != -1)
+            {
+                SsPin::template SetConfiguration<SsPin::Port::Configuration::AltFunc>();
+                SsPin::template SetDriverType<SsPin::DriverType::PushPull>();
+                SsPin::template AltFuncNumber<_SsPins::alt_functions[ssPinNumber]>();
+            }
+        }
+
+        template<typename _Regs, typename _Clock, typename _MosiPins, typename _MisoPins, typename _ClockPins, typename _SsPins, typename _DmaTx, typename _DmaRx>
+        template<typename MosiPin, typename MisoPin, typename ClockPin, typename SsPin>
+        void Spi<_Regs, _Clock, _MosiPins, _MisoPins, _ClockPins, _SsPins, _DmaTx, _DmaRx>::SelectPins()
+        {
+            constexpr auto mosiPinIndex = !std::is_same_v<MosiPin, IO::NullPin>
+                                ? _MosiPins::io_pins::template IndexOf<MosiPin>
+                                : -1;
+            constexpr auto misoPinIndex = !std::is_same_v<MisoPin, IO::NullPin>
+                                ? _MisoPins::io_pins:: template IndexOf<MisoPin>
+                                : -1;
+            constexpr auto clockPinIndex = _ClockPins::io_pins:: template IndexOf<ClockPin>;
+
+            constexpr auto ssPinIndex = !std::is_same_v<SsPin, IO::NullPin>
+                                ? _SsPins::io_pins:: template IndexOf<SsPin>
+                                : -1;
+
+            static_assert(mosiPinIndex >= -1);
+            static_assert(misoPinIndex >= -1);
+            static_assert(clockPinIndex >= 0);
+            static_assert(ssPinIndex >= -1);
+
+            SelectPins<mosiPinIndex, misoPinIndex, clockPinIndex, ssPinIndex>();
+        }
+
+        IO_STRUCT_WRAPPER(SPI1, Spi1Regs, SPI_TypeDef);
+        IO_STRUCT_WRAPPER(SPI2, Spi2Regs, SPI_TypeDef);
+        IO_STRUCT_WRAPPER(SPI3, Spi3Regs, SPI_TypeDef);
+    #if defined(SPI4)
+        IO_STRUCT_WRAPPER(SPI4, Spi4Regs, SPI_TypeDef);
+    #endif
+
+        struct Spi1SsPins
+        {
+            using io_pins = IO::PinList<IO::Pa4, IO::Pa15>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi1ClockPins
+        {
+            using io_pins = IO::PinList<IO::Pa5, IO::Pb3>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi1MisoPins
+        {
+            using io_pins = IO::PinList<IO::Pa6, IO::Pb4>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi1MosiPins
+        {
+            using io_pins = IO::PinList<IO::Pa7, IO::Pb5>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+
+        struct Spi2SsPins
+        {
+            using io_pins = IO::PinList<IO::Pb12>;
+            static constexpr std::array<uint8_t, 1> alt_functions{5};
+        };
+        struct Spi2ClockPins
+        {
+            using io_pins = IO::PinList<IO::Pb13, IO::Pf9, IO::Pf10>;
+            static constexpr std::array<uint8_t, 3> alt_functions{5, 5, 5};
+        };
+        struct Spi2MisoPins
+        {
+            using io_pins = IO::PinList<IO::Pa10, IO::Pb14>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi2MosiPins
+        {
+            using io_pins = IO::PinList<IO::Pa11, IO::Pb15>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+
+        struct Spi3SsPins
+        {
+            using io_pins = IO::PinList<IO::Pa4, IO::Pa15>;
+            static constexpr std::array<uint8_t, 2> alt_functions{6, 6};
+        };
+        struct Spi3ClockPins
+        {
+            using io_pins = IO::PinList<IO::Pb3, IO::Pc10>;
+            static constexpr std::array<uint8_t, 2> alt_functions{6, 6};
+        };
+        struct Spi3MisoPins
+        {
+            using io_pins = IO::PinList<IO::Pb4, IO::Pc11>;
+            static constexpr std::array<uint8_t, 2> alt_functions{6, 6};
+        };
+        struct Spi3MosiPins
+        {
+            using io_pins = IO::PinList<IO::Pb5, IO::Pc12>;
+            static constexpr std::array<uint8_t, 2> alt_functions{6, 6};
+        };
+
+#if defined(SPI4)
+        struct Spi4SsPins
+        {
+            using io_pins = IO::PinList<IO::Pe4, IO::Pe11>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi4ClockPins
+        {
+            using io_pins = IO::PinList<IO::Pe2, IO::Pe12>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi4MisoPins
+        {
+            using io_pins = IO::PinList<IO::Pe5, IO::Pe13>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+        struct Spi4MosiPins
+        {
+            using io_pins = IO::PinList<IO::Pe6, IO::Pe14>;
+            static constexpr std::array<uint8_t, 2> alt_functions{5, 5};
+        };
+#endif
+    }
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Spi1 = Private::Spi<
+        Private::Spi1Regs, 
+        Clock::Spi1Clock, 
+        Private::Spi1MosiPins, 
+        Private::Spi1MisoPins,
+        Private::Spi1ClockPins,
+        Private::Spi1SsPins,
+        _DmaTx,
+        _DmaRx>;
+    using Spi1NoDma = Spi1<>;
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Spi2 = Private::Spi<
+        Private::Spi2Regs, 
+        Clock::Spi2Clock, 
+        Private::Spi2MosiPins, 
+        Private::Spi2MisoPins,
+        Private::Spi2ClockPins,
+        Private::Spi2SsPins,
+        _DmaTx,
+        _DmaRx>;
+    using Spi2NoDma = Spi2<>;
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Spi3 = Private::Spi<
+        Private::Spi3Regs, 
+        Clock::Spi3Clock, 
+        Private::Spi3MosiPins, 
+        Private::Spi3MisoPins,
+        Private::Spi3ClockPins,
+        Private::Spi3SsPins,
+        _DmaTx,
+        _DmaRx>;
+    using Spi3NoDma = Spi3<>;
+
+#if defined(SPI4)
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Spi4 = Private::Spi<
+        Private::Spi4Regs, 
+        Clock::Spi4Clock, 
+        Private::Spi4MosiPins, 
+        Private::Spi4MisoPins,
+        Private::Spi4ClockPins,
+        Private::Spi4SsPins,
+        _DmaTx,
+        _DmaRx>;
+    using Spi4NoDma = Spi4<>;
+#endif
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_SPI_H

--- a/include/zhele/platform/stm32/g4/timer.h
+++ b/include/zhele/platform/stm32/g4/timer.h
@@ -1,0 +1,197 @@
+/**
+ * @file
+ * @brief Macros, templates for timers for stm32g4 series
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_TIMER_H
+#define ZHELE_PLATFORM_STM32_G4_TIMER_H
+
+#include <stm32g4xx.h>
+
+#include "iopins.h"
+#include "../common/timer.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace Zhele::Timers
+{
+    namespace Private
+    {
+        template <typename _Regs, typename _ClockEnReg, IRQn_Type _IRQNumber, template<unsigned> typename _ChPins>
+        template <unsigned _ChannelNumber>
+        void GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::SelectPins(int pinNumber)
+        {
+            using Pins = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::Pins;
+            using PinsConfig = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::PinsConfig;
+            using Type = typename Pins::DataType;
+            Type mask = 1 << pinNumber;
+            Pins::Enable();
+            Pins::SetConfiguration(Pins::Configuration::AltFunc, mask);
+            Pins::SetDriverType(Pins::DriverType::PushPull, mask);
+            Pins::AltFuncNumber(PinsConfig::alt_functions[static_cast<size_t>(pinNumber)], mask);
+        }
+
+        template <typename _Regs, typename _ClockEnReg, IRQn_Type _IRQNumber, template<unsigned> typename _ChPins>
+        template <unsigned _ChannelNumber>
+        template <unsigned PinNumber>
+        void GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::SelectPins()
+        {
+            using Pins = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::Pins;
+            using PinsConfig = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::PinsConfig;
+            using Pin = typename Pins::template Pin<PinNumber>;
+
+            Pin::Port::Enable();
+            Pin::template SetConfiguration<Pin::Port::Configuration::AltFunc>();
+            Pin::template SetDriverType<Pin::Port::DriverType::PushPull>();
+            Pin::template AltFuncNumber<PinsConfig::alt_functions[PinNumber]>();
+        }
+
+        template <typename _Regs, typename _ClockEnReg, IRQn_Type _IRQNumber, template<unsigned> typename _ChPins>
+        template <unsigned _ChannelNumber>
+        template <typename Pin>
+        void GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::SelectPins()
+        {
+            using Pins = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::OutputCompare<_ChannelNumber>::Pins;
+            static_assert(Pins::template IndexOf<Pin> >= 0);
+            
+            SelectPins<Pins::template IndexOf<Pin>>();
+        }
+
+        template <typename _Regs, typename _ClockEnReg, IRQn_Type _IRQNumber, template<unsigned> typename _ChPins>
+        template <unsigned _ChannelNumber>
+        void GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::SelectPins(int pinNumber)
+        {
+            using Pins = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::Pins;
+            using PinsConfig = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::PinsConfig;
+            using Type = typename Pins::DataType;
+            Type mask = 1 << pinNumber;
+            Pins::Enable();
+            Pins::SetConfiguration(mask, Pins::Configuration::AltFunc);
+            Pins::AltFuncNumber(mask, PinsConfig::alt_functions[static_cast<size_t>(pinNumber)]);
+        }
+
+        template <typename _Regs, typename _ClockEnReg, IRQn_Type _IRQNumber, template<unsigned> typename _ChPins>
+        template <unsigned _ChannelNumber>
+        template <unsigned PinNumber>
+        void GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::SelectPins()
+        {
+            using Pins = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::Pins;
+            using PinsConfig = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::PinsConfig;
+            using Pin = typename Pins::template Pin<PinNumber>;
+
+            Pin::Port::Enable();
+            Pin::template SetConfiguration<Pin::Configuration::AltFunc>();
+            Pin::template AltFuncNumber<PinsConfig::alt_functions[PinNumber]>();
+        }
+
+        template <typename _Regs, typename _ClockEnReg, IRQn_Type _IRQNumber, template<unsigned> typename _ChPins>
+        template <unsigned _ChannelNumber>
+        template <typename Pin>
+        void GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::SelectPins()
+        {
+            using Pins = GPTimer<_Regs, _ClockEnReg, _IRQNumber, _ChPins>::InputCapture<_ChannelNumber>::Pins;
+            static_assert(Pins::template IndexOf<Pin> >= 0);
+            
+            SelectPins<Pins::template IndexOf<Pin>>();
+        }
+
+        using namespace Zhele::IO;
+
+        template<unsigned ChannelNumber> struct Tim1ChPins;
+        template<> struct Tim1ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa8, Pc0>; static constexpr std::array<uint8_t, 2> alt_functions{6, 2}; }; };
+        template<> struct Tim1ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pa9, Pc1>; static constexpr std::array<uint8_t, 2> alt_functions{6, 2}; }; };
+        template<> struct Tim1ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pa10, Pc2>; static constexpr std::array<uint8_t, 2> alt_functions{6, 2}; }; };
+        template<> struct Tim1ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pa11, Pc3>; static constexpr std::array<uint8_t, 2> alt_functions{11, 2}; }; };
+
+        template<unsigned ChannelNumber> struct Tim2ChPins;
+        template<> struct Tim2ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa0, Pa5, Pa15>; static constexpr std::array<uint8_t, 3> alt_functions{1, 1, 1}; }; };
+        template<> struct Tim2ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pa1, Pb3>; static constexpr std::array<uint8_t, 2> alt_functions{1, 1}; }; };
+        template<> struct Tim2ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pa2, Pb10>; static constexpr std::array<uint8_t, 2> alt_functions{1, 1}; }; };
+        template<> struct Tim2ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pa3, Pb11>; static constexpr std::array<uint8_t, 2> alt_functions{1, 1}; }; };
+
+        template<unsigned ChannelNumber> struct Tim3ChPins;
+        template<> struct Tim3ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa6, Pb4, Pc6>; static constexpr std::array<uint8_t, 3> alt_functions{2, 2, 2}; }; };
+        template<> struct Tim3ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pa4, Pa7, Pb5, Pc7>; static constexpr std::array<uint8_t, 4> alt_functions{2, 2, 2, 2}; }; };
+        template<> struct Tim3ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pb0, Pc8>; static constexpr std::array<uint8_t, 2> alt_functions{2, 2}; }; };
+        template<> struct Tim3ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pb1, Pc9>; static constexpr std::array<uint8_t, 2> alt_functions{2, 2}; }; };
+
+        template<unsigned ChannelNumber> struct Tim4ChPins;
+        template<> struct Tim4ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pb6, Pd12>; static constexpr std::array<uint8_t, 2> alt_functions{2, 2}; }; };
+        template<> struct Tim4ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pb7, Pd13>; static constexpr std::array<uint8_t, 2> alt_functions{2, 2}; }; };
+        template<> struct Tim4ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pd14>; static constexpr std::array<uint8_t, 1> alt_functions{2}; }; };
+        template<> struct Tim4ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pb9, Pd15>; static constexpr std::array<uint8_t, 2> alt_functions{2, 2}; }; };
+
+#if defined (TIM5)
+        template<unsigned ChannelNumber> struct Tim5ChPins;
+        template<> struct Tim5ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa0, Pb2>; static constexpr std::array<uint8_t, 2> alt_functions{2, 2}; }; };
+        template<> struct Tim5ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pa1>; static constexpr std::array<uint8_t, 1> alt_functions{2}; }; };
+        template<> struct Tim5ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pa2>; static constexpr std::array<uint8_t, 1> alt_functions{2}; }; };
+        template<> struct Tim5ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pa3>; static constexpr std::array<uint8_t, 1> alt_functions{2}; }; };
+#endif
+
+        template<unsigned ChannelNumber> struct Tim8ChPins;
+        template<> struct Tim8ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa15, Pb6, Pc6>; static constexpr std::array<uint8_t, 3> alt_functions{2, 5, 4}; }; };
+        template<> struct Tim8ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pa14, Pc7>; static constexpr std::array<uint8_t, 2> alt_functions{5, 4}; }; };
+        template<> struct Tim8ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pb9, Pc8>; static constexpr std::array<uint8_t, 2> alt_functions{10, 4}; }; };
+        template<> struct Tim8ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pc9>; static constexpr std::array<uint8_t, 1> alt_functions{4}; }; };
+
+        template<unsigned ChannelNumber> struct Tim15ChPins;
+        template<> struct Tim15ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa2, Pb14>; static constexpr std::array<uint8_t, 2> alt_functions{9, 1}; }; };
+        template<> struct Tim15ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pa3, Pb15>; static constexpr std::array<uint8_t, 2> alt_functions{9, 1}; }; };
+
+        template<unsigned ChannelNumber> struct Tim16ChPins;
+        template<> struct Tim16ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa6, Pa12, Pb4, Pb8>; static constexpr std::array<uint8_t, 4> alt_functions{1, 1, 1, 1}; }; };
+
+        template<unsigned ChannelNumber> struct Tim17ChPins;
+        template<> struct Tim17ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pa7, Pb5, Pb9>; static constexpr std::array<uint8_t, 3> alt_functions{1, 10, 1}; }; };
+
+#if defined (TIM20)
+        template<unsigned ChannelNumber> struct Tim20ChPins;
+        template<> struct Tim20ChPins<0>{ struct Pins { using io_pins = IO::PinList<Pb2, Pf12>; static constexpr std::array<uint8_t, 2> alt_functions{3, 2}; }; };
+        template<> struct Tim20ChPins<1>{ struct Pins { using io_pins = IO::PinList<Pf13>; static constexpr std::array<uint8_t, 1> alt_functions{2}; }; };
+        template<> struct Tim20ChPins<2>{ struct Pins { using io_pins = IO::PinList<Pc8, Pf14>; static constexpr std::array<uint8_t, 2> alt_functions{6, 2}; }; };
+        template<> struct Tim20ChPins<3>{ struct Pins { using io_pins = IO::PinList<Pe1, Pf15>; static constexpr std::array<uint8_t, 2> alt_functions{6, 2}; }; };
+#endif
+
+        IO_STRUCT_WRAPPER(TIM1, Tim1Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM2, Tim2Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM3, Tim3Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM4, Tim4Regs, TIM_TypeDef);
+    #if defined (TIM5)
+        IO_STRUCT_WRAPPER(TIM5, Tim5Regs, TIM_TypeDef);
+    #endif
+        IO_STRUCT_WRAPPER(TIM6, Tim6Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM7, Tim7Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM8, Tim8Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM15, Tim15Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM16, Tim16Regs, TIM_TypeDef);
+        IO_STRUCT_WRAPPER(TIM17, Tim17Regs, TIM_TypeDef);
+    #if defined (TIM20)
+        IO_STRUCT_WRAPPER(TIM20, Tim20Regs, TIM_TypeDef);
+    #endif
+    }
+
+    using Timer1 = Private::AdvancedTimer<Private::Tim1Regs, Clock::Tim1Clock, TIM1_UP_TIM16_IRQn, Private::Tim1ChPins>;
+    using Timer2 = Private::GPTimer<Private::Tim2Regs, Clock::Tim2Clock, TIM2_IRQn, Private::Tim2ChPins>;
+    using Timer3 = Private::GPTimer<Private::Tim3Regs, Clock::Tim3Clock, TIM3_IRQn, Private::Tim3ChPins>;
+    using Timer4 = Private::GPTimer<Private::Tim4Regs, Clock::Tim4Clock, TIM4_IRQn, Private::Tim4ChPins>;
+#if defined (TIM5)
+    using Timer5 = Private::GPTimer<Private::Tim5Regs, Clock::Tim5Clock, TIM5_IRQn, Private::Tim5ChPins>;
+#endif
+    using Timer6 = Private::BaseTimer<Private::Tim6Regs, Clock::Tim6Clock, TIM6_DAC_IRQn>;
+    using Timer7 = Private::BaseTimer<Private::Tim7Regs, Clock::Tim7Clock, TIM7_DAC_IRQn>;
+    using Timer8 = Private::AdvancedTimer<Private::Tim8Regs, Clock::Tim8Clock, TIM8_UP_IRQn, Private::Tim8ChPins>;
+    using Timer15 = Private::GPTimer<Private::Tim15Regs, Clock::Tim15Clock, TIM1_BRK_TIM15_IRQn, Private::Tim15ChPins>;
+    using Timer16 = Private::GPTimer<Private::Tim16Regs, Clock::Tim16Clock, TIM1_UP_TIM16_IRQn, Private::Tim16ChPins>;
+    using Timer17 = Private::GPTimer<Private::Tim17Regs, Clock::Tim17Clock, TIM1_TRG_COM_TIM17_IRQn, Private::Tim17ChPins>;
+#if defined (TIM20)
+    using Timer20 = Private::AdvancedTimer<Private::Tim20Regs, Clock::Tim20Clock, TIM20_UP_IRQn, Private::Tim20ChPins>;
+#endif
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_TIMER_H

--- a/include/zhele/platform/stm32/g4/usart.h
+++ b/include/zhele/platform/stm32/g4/usart.h
@@ -1,0 +1,181 @@
+/**
+ * @file
+ * @brief Implements USART protocol for stm32g4 series
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_USART_H
+#define ZHELE_PLATFORM_STM32_G4_USART_H
+
+#include <stm32g4xx.h>
+
+#include "../common/usart.h"
+
+#include "clock.h"
+#include "dma.h"
+#include "iopins.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace Zhele
+{
+    namespace Private
+    {
+        template<typename _Regs, IRQn_Type _IRQNumber, typename _ClockCtrl, typename _TxPins, typename _RxPins, typename _DmaTx, typename _DmaRx>
+        void Usart<_Regs, _IRQNumber, _ClockCtrl, _TxPins, _RxPins, _DmaTx, _DmaRx>::SelectTxRxPins(int8_t txPinNumber, int8_t rxPinNumber)
+        {
+            using TxPins = typename _TxPins::io_pins;
+            using RxPins = typename _RxPins::io_pins;
+
+            using Type = typename TxPins::DataType;
+
+            TxPins::Enable();
+            Type maskTx(1 << txPinNumber);
+            TxPins::SetConfiguration(TxPins::Configuration::AltFunc, maskTx);
+            TxPins::AltFuncNumber(_TxPins::alt_functions[static_cast<size_t>(txPinNumber)], maskTx);
+
+            if(rxPinNumber != -1)
+            {
+                RxPins::Enable();
+                Type maskRx(1 << rxPinNumber);
+                RxPins::SetConfiguration(RxPins::Configuration::AltFunc, maskRx);
+                RxPins::AltFuncNumber(_RxPins::alt_functions[static_cast<size_t>(rxPinNumber)], maskRx);
+            }
+        }
+
+        template<typename _Regs, IRQn_Type _IRQNumber, typename _ClockCtrl, typename _TxPins, typename _RxPins, typename _DmaTx, typename _DmaRx>
+        template<int8_t TxPinNumber, int8_t RxPinNumber>
+        void Usart<_Regs, _IRQNumber, _ClockCtrl, _TxPins, _RxPins, _DmaTx, _DmaRx>::SelectTxRxPins()
+        {
+            using TxPin = typename _TxPins::io_pins::template Pin<TxPinNumber>;
+
+            TxPin::Port::Enable();
+
+            TxPin::template SetConfiguration<TxPin::Port::Configuration::AltFunc>();
+            TxPin::template AltFuncNumber<_TxPins::alt_functions[TxPinNumber]>();
+
+            if constexpr(RxPinNumber != -1)
+            {
+                using RxPin = typename _RxPins::io_pins::template Pin<RxPinNumber>;
+
+                if constexpr (!std::is_same_v<typename RxPin::Port, typename TxPin::Port>) {
+                    RxPin::Port::Enable();
+                }
+
+                RxPin::template SetConfiguration<RxPin::Port::Configuration::AltFunc>();
+                RxPin::template AltFuncNumber<_RxPins::alt_functions[RxPinNumber]>();
+            }
+        }
+
+        template<typename _Regs, IRQn_Type _IRQNumber, typename _ClockCtrl, typename _TxPins, typename _RxPins, typename _DmaTx, typename _DmaRx>
+        template<typename TxPin, typename RxPin>
+        void Usart<_Regs, _IRQNumber, _ClockCtrl, _TxPins, _RxPins, _DmaTx, _DmaRx>::SelectTxRxPins()
+        {
+            const int8_t txPinIndex = _TxPins::io_pins:: template IndexOf<TxPin>;
+            const int8_t rxPinIndex = !std::is_same_v<RxPin, IO::NullPin>
+                                ? _RxPins::io_pins:: template IndexOf<RxPin>
+                                : -1;
+            static_assert(txPinIndex >= 0);
+            static_assert(rxPinIndex >= -1);
+            SelectTxRxPins<txPinIndex, rxPinIndex>();
+        }
+
+        struct Usart1TxPins
+        {
+            using io_pins = IO::PinList<IO::Pa9, IO::Pb6, IO::Pc4, IO::Pe0>;
+            static constexpr std::array<uint8_t, 4> alt_functions{7, 7, 7, 7};
+        };
+        struct Usart1RxPins
+        {
+            using io_pins = IO::PinList<IO::Pa10, IO::Pb7, IO::Pc5, IO::Pe1>;
+            static constexpr std::array<uint8_t, 4> alt_functions{7, 7, 7, 7};
+        };
+
+        struct Usart2TxPins
+        {
+            using io_pins = IO::PinList<IO::Pa2, IO::Pa14, IO::Pb3, IO::Pd5>;
+            static constexpr std::array<uint8_t, 4> alt_functions{7, 7, 7, 7};
+        };
+        struct Usart2RxPins
+        {
+            using io_pins = IO::PinList<IO::Pa3, IO::Pa15, IO::Pb4, IO::Pd6>;
+            static constexpr std::array<uint8_t, 4> alt_functions{7, 7, 7, 7};
+        };
+
+        struct Usart3TxPins
+        {
+            using io_pins = IO::PinList<IO::Pb9, IO::Pb10, IO::Pc10, IO::Pd8>;
+            static constexpr std::array<uint8_t, 4> alt_functions{7, 7, 7, 7};
+        };
+        struct Usart3RxPins
+        {
+            using io_pins = IO::PinList<IO::Pb8, IO::Pb11, IO::Pc11, IO::Pd9, IO::Pe15>;
+            static constexpr std::array<uint8_t, 5> alt_functions{7, 7, 7, 7, 7};
+        };
+
+#if defined (UART4)
+        struct Uart4TxPins
+        {
+            using io_pins = IO::PinList<IO::Pc10>;
+            static constexpr std::array<uint8_t, 1> alt_functions{5};
+        };
+        struct Uart4RxPins
+        {
+            using io_pins = IO::PinList<IO::Pc11>;
+            static constexpr std::array<uint8_t, 1> alt_functions{5};
+        };
+#endif
+
+#if defined (UART5)
+        struct Uart5TxPins
+        {
+            using io_pins = IO::PinList<IO::Pc12>;
+            static constexpr std::array<uint8_t, 1> alt_functions{5};
+        };
+        struct Uart5RxPins
+        {
+            using io_pins = IO::PinList<IO::Pd2>;
+            static constexpr std::array<uint8_t, 1> alt_functions{5};
+        };
+#endif
+
+        IO_STRUCT_WRAPPER(USART1, Usart1Regs, USART_TypeDef);
+        IO_STRUCT_WRAPPER(USART2, Usart2Regs, USART_TypeDef);
+        IO_STRUCT_WRAPPER(USART3, Usart3Regs, USART_TypeDef);
+    #if defined(UART4)
+        IO_STRUCT_WRAPPER(UART4, Uart4Regs, USART_TypeDef);
+    #endif
+    #if defined(UART5)
+        IO_STRUCT_WRAPPER(UART5, Uart5Regs, USART_TypeDef);
+    #endif
+    }
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Usart1 = Private::Usart<Private::Usart1Regs, USART1_IRQn, Clock::Usart1Clock, Private::Usart1TxPins, Private::Usart1RxPins, _DmaTx, _DmaRx>;
+    
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Usart2 = Private::Usart<Private::Usart2Regs, USART2_IRQn, Clock::Usart2Clock, Private::Usart2TxPins, Private::Usart2RxPins, _DmaTx, _DmaRx>;
+
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Usart3 = Private::Usart<Private::Usart3Regs, USART3_IRQn, Clock::Usart3Clock, Private::Usart3TxPins, Private::Usart3RxPins, _DmaTx, _DmaRx>;
+
+#if defined (UART4)
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Uart4 = Private::Usart<Private::Uart4Regs, UART4_IRQn, Clock::Uart4Clock, Private::Uart4TxPins, Private::Uart4RxPins, _DmaTx, _DmaRx>;
+#endif
+
+#if defined (UART5)
+    template<typename _DmaTx = void, typename _DmaRx = void>
+    using Uart5 = Private::Usart<Private::Uart5Regs, UART5_IRQn, Clock::Uart5Clock, Private::Uart5TxPins, Private::Uart5RxPins, _DmaTx, _DmaRx>;
+#endif
+
+    // LPUART1 is not supported yet: its baud rate register uses a different formula
+    // (BRR = 256 * fck / baud, minimum 0x300) which UsartBase::SetBaud does not implement.
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_USART_H

--- a/include/zhele/platform/stm32/g4/usb.h
+++ b/include/zhele/platform/stm32/g4/usb.h
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * Implement USB protocol for stm32g4 series
+ *
+ * @author Aleksei Zhelonkin & Damir Bakiev
+ * @date 2026
+ * @license MIT
+ */
+
+#ifndef ZHELE_PLATFORM_STM32_G4_USB_H
+#define ZHELE_PLATFORM_STM32_G4_USB_H
+
+#include <stm32g4xx.h>
+
+#include "clock.h"
+
+// USB_LP_IRQn/USB_HP_IRQn are IRQn_Type enumerators, not preprocessor macros: the common
+// code's `#if defined(USB_LP_IRQn)` can't see them, so define USB_IRQ here (interrupts for
+// USB device events are wired to the low-priority vector on G4).
+#define USB_IRQ USB_LP_IRQn
+
+#include "../common/usb/device.h"
+
+namespace Zhele::Usb
+{
+    /**
+     * @brief 48 MHz clock source for the USB peripheral (RCC_CCIPR CLK48SEL)
+     */
+    enum class ClockSource
+    {
+        Hsi48, ///< HSI48 RC oscillator, trimmed against USB SOF via CRS (crystal-less USB, reset default)
+        Pll,   ///< PLLQ output (requires PllClock::SetUsbOutputDivider<>() and an HSE crystal)
+    };
+
+    USB_DEVICE_TEMPLATE_ARGS
+    template<auto clockSource>
+    void USB_DEVICE_TEMPLATE_QUALIFIER::SelectClockSource()
+    {
+        static_assert(std::is_same_v<decltype(clockSource), Zhele::Usb::ClockSource>, "Clock source argument must be ClockSource enum value.");
+
+        if constexpr (clockSource == Zhele::Usb::ClockSource::Hsi48)
+        {
+            Zhele::Clock::Hsi48Clock::Enable();
+
+            RCC->APB1ENR1 |= RCC_APB1ENR1_CRSEN;
+            RCC->CCIPR &= ~RCC_CCIPR_CLK48SEL; // 00: HSI48
+            CRS->CR |= CRS_CR_AUTOTRIMEN;
+            CRS->CR |= CRS_CR_CEN;
+        }
+        if constexpr (clockSource == Zhele::Usb::ClockSource::Pll)
+        {
+            RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_CLK48SEL) | RCC_CCIPR_CLK48SEL_0; // 01: PLLQ
+        }
+    }
+}
+
+#endif //! ZHELE_PLATFORM_STM32_G4_USB_H

--- a/include/zhele/platform/stm32/i2c.h
+++ b/include/zhele/platform/stm32/i2c.h
@@ -25,6 +25,9 @@
 #if defined(STM32G0)
     #include "g0/i2c.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/i2c.h"
+#endif
 #if defined(STM32C0)
     #include "c0/i2c.h"
 #endif

--- a/include/zhele/platform/stm32/iopins.h
+++ b/include/zhele/platform/stm32/iopins.h
@@ -28,5 +28,8 @@
 #if defined(STM32G0)
     #include "g0/iopins.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/iopins.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_IOPINS_H

--- a/include/zhele/platform/stm32/ioports.h
+++ b/include/zhele/platform/stm32/ioports.h
@@ -28,5 +28,8 @@
 #if defined(STM32G0)
     #include "g0/ioports.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/ioports.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_IOPORTS_H

--- a/include/zhele/platform/stm32/pinlist.h
+++ b/include/zhele/platform/stm32/pinlist.h
@@ -25,5 +25,8 @@
 #if defined(STM32G0)
     #include "g0/pinlist.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/pinlist.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_PINLIST_H

--- a/include/zhele/platform/stm32/platform_detector.h
+++ b/include/zhele/platform/stm32/platform_detector.h
@@ -7,7 +7,7 @@
 
 #if defined(ZHELE_PLATFORM_STM32)
 #elif defined(STM32C0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) \
-    || defined(STM32G0) || defined(STM32L4) || defined(STM32L0) || defined(STM32H7)
+    || defined(STM32G0) || defined(STM32G4) || defined(STM32L4) || defined(STM32L0) || defined(STM32H7)
 #define ZHELE_PLATFORM_STM32 1
 #endif
 

--- a/include/zhele/platform/stm32/rng.h
+++ b/include/zhele/platform/stm32/rng.h
@@ -21,5 +21,8 @@
 #if defined(STM32G0)
     #error STM32G0 does not support RNG
 #endif
+#if defined(STM32G4)
+    #include "g4/rng.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_RNG_H

--- a/include/zhele/platform/stm32/spi.h
+++ b/include/zhele/platform/stm32/spi.h
@@ -25,5 +25,8 @@
 #if defined(STM32G0)
     #include "g0/spi.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/spi.h"
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_SPI_H

--- a/include/zhele/platform/stm32/timer.h
+++ b/include/zhele/platform/stm32/timer.h
@@ -24,6 +24,9 @@
 #if defined(STM32G0)
     #include "g0/timer.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/timer.h"
+#endif
 #if defined(STM32C0)
     #include "c0/timer.h"
 #endif

--- a/include/zhele/platform/stm32/usart.h
+++ b/include/zhele/platform/stm32/usart.h
@@ -24,6 +24,9 @@
 #if defined(STM32G0)
     #include "g0/usart.h"
 #endif
+#if defined(STM32G4)
+    #include "g4/usart.h"
+#endif
 #if defined(STM32C0)
     #include "c0/usart.h"
 #endif

--- a/include/zhele/platform/stm32/usb.h
+++ b/include/zhele/platform/stm32/usb.h
@@ -25,7 +25,7 @@
     #include "g0/usb.h"
 #endif
 #if defined(STM32G4)
-    #error USB for STM32G4 is not implemented yet
+    #include "g4/usb.h"
 #endif
 
 #endif // ZHELE_PLATFORM_STM32_USB_H

--- a/include/zhele/platform/stm32/usb.h
+++ b/include/zhele/platform/stm32/usb.h
@@ -24,5 +24,8 @@
 #if defined(STM32G0)
     #include "g0/usb.h"
 #endif
+#if defined(STM32G4)
+    #error USB for STM32G4 is not implemented yet
+#endif
 
 #endif // ZHELE_PLATFORM_STM32_USB_H

--- a/include/zhele/platform/stm32/watchdog.h
+++ b/include/zhele/platform/stm32/watchdog.h
@@ -21,6 +21,9 @@
 #if defined(STM32G0)
     #include <stm32g0xx.h>
 #endif
+#if defined(STM32G4)
+    #include <stm32g4xx.h>
+#endif
 
 #include "common/watchdog.h"
 


### PR DESCRIPTION
## Summary

Adds full STM32G4 family support to zhele, brought up to feature parity with G0/F4 and verified on real hardware (NUCLEO-G431KB and NUCLEO-G474RE), not just compile-tested.

- **Clock**: correct PLL field encodings (M-1, direct N, SYSCLK from PLLR, 2-bit PLLSRC/PLLQ), HSI48 + boost mode for 170 MHz operation
- **Flash**: per-device size table, 0–4 wait states, dual-bank erase
- **GPIO/DMA/DMAMUX**: device-correct channel counts (6 vs 8 per controller), RM0440 request/sync tables
- **EXTI**: per-line IRQ mapping and EXTICR fix
- **I2C/SPI/USART**: split event/error IRQs, I2C3/I2C4, SPI3/SPI4, UART4/UART5, correct alternate-function numbers
- **Timers**: TIM1..TIM8, TIM15..TIM17, TIM20 (guarded for G474-only instances) with corrected pin maps
- **RNG**
- **ADC**: native driver (the shared F1-style engine isn't register-compatible with G4's SAR ADC) — calibration, single conversion, DMA regular sequence, VREFINT/temperature reading
- **USB device**: HSI48+CRS crystal-less or PLLQ clock source; the shared `USB` (non-OTG) peripheral code needed no changes

## Bugs fixed in shared code along the way

Found while bringing G4 up and confirmed on real hardware — these affect every family, not just G4:

- `USB_IRQ` detection relied on `#if defined(USB_LP_IRQn)`, but split low/high-priority IRQs are `IRQn_Type` enumerators, not preprocessor macros, so the check silently never fired
- `CdcCommInterface`'s functional-descriptor builder was named `FillDescriptor()` while the generic interface walker calls `GetDescriptor()` — CDC-ACM devices on every family were emitting a configuration descriptor missing the CS_INTERFACE descriptors (Header/Call Management/ACM/Union) entirely, silently failing `cdc_acm` enumeration
- DAC output-buffer control (`BOFF`) doesn't exist on G0/L4/G4-style DAC IP (uses `MCR.MODE` instead); added high-frequency-mode selection while there

## Verification

- Full syntax matrix (`-fsyntax-only`, `-Wall -Wextra -Wpedantic -Werror`, `gnu++26`) for every header individually and combined, under both `STM32G431xx` and `STM32G474xx`
- Real hardware, NUCLEO-G431KB: 170 MHz clock, flash erase/write/verify, RNG, ADC (Vdda/temperature), I2C bus scan, all confirmed over UART
- Real hardware, NUCLEO-G474RE: G474-only guard branches (TIM5/TIM20, DMA channels 7/8, ADC3, I2C4, SPI4, UART5) confirmed via RAM markers read over SWD; USB CDC-ACM enumerated and echoed data round-trip over `/dev/ttyACM*`
- Consumer project builds cleanly end-to-end via `FetchContent` with no local overrides

## Known limitations

- LPUART1 not implemented (different BRR formula, documented in `usart.h`)
- G474-only ADC3/4/5 and SPI4/I2C4 pin maps are minimal (cover the LQFP64 package tested against) — flagged for extension
- USB device support is G4-only in this PR; other missing families are unrelated pre-existing gaps

Co-Authored-By: Claude Fable 5 
