### PR TITLE
Add CH32 flash driver for V0 and V2

### DIFF
--- a/example/ch32/CMakeLists.txt
+++ b/example/ch32/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(CMSIS COMPONENTS CH32V0 CH32V2 REQUIRED)
 
 add_subdirectory(Clock)
 add_subdirectory(Drivers)
+add_subdirectory(Flash)
 add_subdirectory(GPIO)
 add_subdirectory(Spi)
 add_subdirectory(Timer)

--- a/example/ch32/Flash/CMakeLists.txt
+++ b/example/ch32/Flash/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Storage)

--- a/example/ch32/Flash/Storage/CMakeLists.txt
+++ b/example/ch32/Flash/Storage/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../wch_cmake/cmake/wch_gcc.cmake)
+
+project(flash_storage CXX C ASM)
+
+ch32_fetch_cmsis(V0 V2)
+find_package(CMSIS COMPONENTS CH32V0 CH32V2 REQUIRED)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../../include)
+
+add_executable(flash_storage_v003 main.cpp)
+target_compile_features(flash_storage_v003 PRIVATE cxx_std_23)
+target_link_libraries(flash_storage_v003 CMSIS::CH32::V003F4 CH32::Nano CH32::NoSys)
+ch32_print_size_of_target(flash_storage_v003)
+ch32_generate_hex_file(flash_storage_v003)
+
+add_executable(flash_storage_v006 main.cpp)
+target_compile_features(flash_storage_v006 PRIVATE cxx_std_23)
+target_link_libraries(flash_storage_v006 CMSIS::CH32::V006K8 CH32::Nano CH32::NoSys)
+ch32_print_size_of_target(flash_storage_v006)
+ch32_generate_hex_file(flash_storage_v006)
+
+add_executable(flash_storage_v203 main.cpp)
+target_compile_features(flash_storage_v203 PRIVATE cxx_std_23)
+target_compile_definitions(flash_storage_v203 PRIVATE CH32V203)
+target_link_libraries(flash_storage_v203 CMSIS::CH32::V203C8 CH32::Nano CH32::NoSys)
+ch32_print_size_of_target(flash_storage_v203)
+ch32_generate_hex_file(flash_storage_v203)

--- a/example/ch32/Flash/Storage/main.cpp
+++ b/example/ch32/Flash/Storage/main.cpp
@@ -1,0 +1,48 @@
+/**
+ * Flash storage — erase the last flash page, write a string into it and read it
+ * back (V003 / V006 / V203).
+ *
+ * The LED lights up if what was read back matches what was written.
+ *
+ * LED pin (adjust to your board):
+ *   CH32V003 / CH32V006 -> PC4
+ *   CH32V203            -> PB2
+ */
+#include <zhele/flash.h>
+#include <zhele/iopins.h>
+#include <zhele/delay.h>
+
+using namespace Zhele;
+using namespace Zhele::IO;
+
+#if defined(CH32V203)
+using Led = Pb2;
+#else
+using Led = Pc4;
+#endif
+
+// The last page is outside the .text/.rodata the linker fills, so it is free to use.
+static constexpr unsigned StoragePage = Flash::PageCount() - 1;
+
+int main()
+{
+    Led::Port::Enable();
+    Led::SetConfiguration<Led::Configuration::Out>();
+    Led::SetDriverType<Led::DriverType::PushPull>();
+
+    const char data[] = "Some data for store into flash";
+    // volatile: flash content changes behind the compiler's back.
+    auto storage = reinterpret_cast<const volatile char*>(Flash::PageAddress(StoragePage));
+
+    bool success = Flash::ErasePage(StoragePage)
+        && Flash::WritePage(StoragePage, data, sizeof(data), 0);
+
+    for (unsigned i = 0; success && i < sizeof(data); ++i) {
+        success = storage[i] == data[i];
+    }
+
+    for (;;) {
+        Led::Set(success);
+        delay_ms<500>();
+    }
+}

--- a/include/zhele/platform/ch32/common/clock.h
+++ b/include/zhele/platform/ch32/common/clock.h
@@ -7,6 +7,8 @@
 
 #include "ioreg.h"
 
+#include <zhele/flash.h>
+
 namespace Zhele::Clock
 {
   // PB2PCENR on new V00x, APB2PCENR else
@@ -199,6 +201,7 @@ namespace Zhele::Clock
   {
     uint32_t swBits;
     uint32_t swsValue;
+    ClockFrequenceT resultFrequence;
 
     if constexpr (clockSource == Internal)
     {
@@ -206,6 +209,7 @@ namespace Zhele::Clock
         return ClockSourceFailed;
       swBits = RCC_SW_HSI;
       swsValue = SwsHsi;
+      resultFrequence = HsiClock::ClockFreq();
     }
     else if constexpr (clockSource == External)
     {
@@ -213,6 +217,7 @@ namespace Zhele::Clock
         return ClockSourceFailed;
       swBits = RCC_SW_HSE;
       swsValue = SwsHse;
+      resultFrequence = HseClock::ClockFreq();
     }
     else if constexpr (clockSource == Pll)
     {
@@ -220,11 +225,18 @@ namespace Zhele::Clock
         return ClockSourceFailed;
       swBits = RCC_SW_PLL;
       swsValue = SwsPll;
+      resultFrequence = PllClock::ClockFreq();
     }
     else
     {
       return InvalidClockSource;
     }
+
+    // Flash wait states must cover the higher of the two frequencies for the
+    // whole switch: raise them before speeding up, lower them only afterwards.
+    ClockFrequenceT currentFrequence = ClockFreq();
+    if (resultFrequence > currentFrequence)
+      Flash::ConfigureFrequence(resultFrequence);
 
     RCC->CFGR0 = (RCC->CFGR0 & ~static_cast<uint32_t>(RCC_SW)) | swBits;
 
@@ -232,7 +244,13 @@ namespace Zhele::Clock
     while (((RCC->CFGR0 & RCC_SWS) != swsValue) && --timeout)
       ;
 
-    return timeout != 0 ? Success : ClockSelectFailed;
+    if (timeout == 0)
+      return ClockSelectFailed;
+
+    if (resultFrequence <= currentFrequence)
+      Flash::ConfigureFrequence(resultFrequence);
+
+    return Success;
   }
 
   inline ClockFrequenceT SysClock::ClockFreq()

--- a/include/zhele/platform/ch32/common/flash.h
+++ b/include/zhele/platform/ch32/common/flash.h
@@ -1,0 +1,276 @@
+/**
+ * @file
+ * Flash controller for CH32 (WCH FPEC)
+ *
+ * @details The WCH flash controller is an STM32F1-style FPEC with renamed
+ * registers (KEYR / STATR / CTLR / ADDR). Two programming modes exist:
+ *
+ *  - *standard* mode — halfword (16-bit) programming via `CTLR.PG`, erase by
+ *    sector via `CTLR.PER` (1 KB on V0, 4 KB on V2). Used wherever the part
+ *    supports it (CH32V003, CH32V20x).
+ *  - *fast* mode — a 256-byte page buffer (`CTLR.PAGE_PG` + `BUF_RST`/`BUF_LOAD`)
+ *    unlocked through `MODEKEYR`. The newer V00x parts (V002/4/5/6/7) dropped
+ *    standard programming, so there the write path uses this instead; erase
+ *    still goes through the 1 KB `PER` sector erase.
+ *
+ * The family header picks the path by defining `ZHELE_CH32_FLASH_FAST_PROGRAMMING`
+ * before including this file.
+ *
+ * @note Flash is visible at two aliases: 0x00000000 (execution, what the CH32
+ * linker scripts use) and 0x08000000 (programming, what the reference manual
+ * uses). Any address accepted by this class may be given in either alias;
+ * everything is normalized to 0x08000000 before it reaches the controller.
+ * `PageAddress()` returns the execution alias, so it matches linker symbols.
+ *
+ * @author Aleksei Zhelonkin (based on the STM32 flash implementation by Konstantin Chizhov)
+ * @license MIT
+ */
+#ifndef ZHELE_PLATFORM_CH32_COMMON_FLASH_H
+#define ZHELE_PLATFORM_CH32_COMMON_FLASH_H
+
+#include <cstdint>
+
+namespace Zhele
+{
+    class Flash
+    {
+        /// @brief FPEC unlock keys
+        static constexpr uint32_t FlashKey1 = 0x45670123UL;
+        static constexpr uint32_t FlashKey2 = 0xCDEF89ABUL;
+
+        /// @brief Mask which strips the alias (0x00000000 / 0x08000000) from an address
+        static constexpr uint32_t AliasMask = 0x0007FFFFUL;
+
+    public:
+        /**
+         * @brief Configure flash wait states for target system frequency
+         *
+         * @param [in] frequence Target HCLK frequency
+         *
+         * @par Returns
+         *  Nothing
+        */
+        static void ConfigureFrequence(uint32_t frequence);
+
+        /**
+         * @brief Returns total flash size
+         *
+         * @returns Flash size in bytes
+        */
+        static constexpr uint32_t FlashSize();
+
+        /**
+         * @brief Returns flash page (erase granularity) size
+         *
+         * @param [in] page Page number
+         *
+         * @returns Page size in bytes
+        */
+        static constexpr uint32_t PageSize(unsigned page);
+
+        /**
+         * @brief Returns flash page count
+         *
+         * @returns Page count
+        */
+        static constexpr uint32_t PageCount();
+
+        /**
+         * @brief Calculates page begin address
+         *
+         * @param [in] page Page number
+         *
+         * @returns Page address (execution alias, as used by the linker scripts)
+        */
+        static constexpr uint32_t PageAddress(unsigned page);
+
+        /**
+         * @brief Calculates page number by address
+         *
+         * @param [in] address Address (either alias)
+         *
+         * @returns Page number
+        */
+        static constexpr unsigned AddressToPage(const void* address);
+
+        /**
+         * @brief Unlock flash
+         *
+         * @retval true Flash is unlocked
+         * @retval false Unlock failed
+        */
+        static bool Unlock();
+
+        /**
+         * @brief Lock flash
+         *
+         * @par Returns
+         *  Nothing
+        */
+        static void Lock();
+
+        /**
+         * @brief Returns flash lock status
+         *
+         * @retval true Flash is locked
+         * @retval false Flash is unlocked
+        */
+        static bool IsLock();
+
+        /**
+         * @brief Erase flash page
+         *
+         * @note Do not confirm the result by blank-checking for 0xFF. It holds
+         * on V00x but not on CH32V203, where a successfully erased sector reads
+         * back as a fixed pattern (0xE339E339 in every word) until something is
+         * programmed into it. The erase is real nonetheless — the sector accepts
+         * the 0->1 bit changes only an erased one can take, and the data
+         * persists across resets. Both were verified on hardware.
+         *
+         * @param [in] page Page number
+         *
+         * @retval true Erase success
+         * @retval false Erase failed
+        */
+        static bool ErasePage(uint32_t page);
+
+        /**
+         * @brief Writes data to flash, checking that it stays inside one page
+         *
+         * @param [in] dst Destination address
+         * @param [in] src Data to write
+         * @param [in] size Data size
+         *
+         * @retval true Write success
+         * @retval false Write failed
+        */
+        static bool WritePage(void* dst, const void* src, unsigned size);
+
+        /**
+         * @brief Writes data to the given flash page
+         *
+         * @param [in] page Page number
+         * @param [in] src Data to write
+         * @param [in] size Data size
+         * @param [in] offset Offset inside the page
+         *
+         * @retval true Write success
+         * @retval false Write failed
+        */
+        static bool WritePage(unsigned page, const void* src, unsigned size, unsigned offset);
+
+        /**
+         * @brief Writes data to flash
+         *
+         * @details The target area must be erased beforehand. On parts programmed
+         * in standard mode the destination address must be halfword-aligned and an
+         * odd size gets its tail padded with 0xFF; on fast-programming parts any
+         * alignment is accepted, the driver reprograms whole 256-byte pages and
+         * refills the untouched words from their current content.
+         *
+         * @param [in] dst Destination address
+         * @param [in] src Data to write
+         * @param [in] size Data size
+         *
+         * @retval true Write success
+         * @retval false Write failed
+        */
+        static bool WriteFlash(void* dst, const void* src, unsigned size);
+
+    private:
+        /**
+         * @brief Translates any flash alias into the programming one (0x08000000)
+         *
+         * @param [in] address Address to translate
+         *
+         * @returns Address in the programming alias
+        */
+        static constexpr uint32_t Normalize(uint32_t address);
+
+        /**
+         * @brief Block execution while flash busy
+         *
+         * @par Returns
+         *  Nothing
+        */
+        static void WaitWhileBusy();
+
+        /**
+         * @brief Wait for a just-triggered erase/program to finish
+         *
+         * @details Waits for `STATR.BSY` to appear (the controller needs a few
+         * cycles to raise it, so polling for "not busy" straight away would see
+         * the previous idle state) and then to drop, and finally requires
+         * `STATR.EOP`. The flag is raised by hardware on completion — `CTLR.EOPIE`
+         * is *not* needed for it, and is deliberately left alone so this driver
+         * never enables an interrupt behind the application's back.
+         *
+         * @note Do not verify an erase by reading 0xFF instead: on CH32V203 an
+         * erased sector reads back as a fixed pattern (0xE339E339 in every word)
+         * until something is programmed into it, even though the erase itself
+         * completed and the sector accepts 0->1 bit changes afterwards.
+         *
+         * @retval true Operation completed
+         * @retval false Timed out
+        */
+        static bool WaitForOperation();
+
+        /// @brief Poll count allowed for one erase/program before giving up
+        static constexpr uint32_t OperationTimeout = 2000000;
+
+        /**
+         * @brief Clears sticky status flags before starting an operation
+         *
+         * @par Returns
+         *  Nothing
+        */
+        static void ClearStatus();
+
+        /**
+         * @brief Clears sticky status flags and reports whether last operation succeeded
+         *
+         * @retval true Last operation completed without errors
+         * @retval false Write protection or programming error was detected
+        */
+        static bool CheckAndClearStatus();
+
+    #if defined(ZHELE_CH32_FLASH_FAST_PROGRAMMING)
+        /// @brief Fast-mode page (program granularity) size in bytes
+        static constexpr uint32_t FastPageSize = 256;
+
+        /**
+         * @brief CTLR bits driving the fast page buffer
+         *
+         * @details Spelled out instead of taken from the CMSIS header: the WCH
+         * V00x header casts these to `uint16_t`
+         * (`#define FLASH_CTLR_PAGE_PG ((uint16_t)0x00010000)`), which truncates
+         * them to zero. WCH's own SPL works around the same thing by redefining
+         * them in `ch32v00x_flash.c`.
+        */
+        static constexpr uint32_t CtlrPageProgram = 0x00010000UL;
+        static constexpr uint32_t CtlrPageErase = 0x00020000UL;
+        static constexpr uint32_t CtlrBufferLoad = 0x00040000UL;
+        static constexpr uint32_t CtlrBufferReset = 0x00080000UL;
+
+        /**
+         * @brief Unlock flash and fast program/erase mode
+         *
+         * @retval true Both locks are released
+         * @retval false Unlock failed
+        */
+        static bool UnlockFast();
+
+        /**
+         * @brief Lock fast program/erase mode and flash itself
+         *
+         * @par Returns
+         *  Nothing
+        */
+        static void LockFast();
+    #endif
+    };
+}
+
+#include "impl/flash.h"
+
+#endif //! ZHELE_PLATFORM_CH32_COMMON_FLASH_H

--- a/include/zhele/platform/ch32/common/impl/flash.h
+++ b/include/zhele/platform/ch32/common/impl/flash.h
@@ -1,0 +1,280 @@
+/**
+ * @file
+ * Flash controller implementation for CH32 (WCH FPEC)
+ *
+ * @author Aleksei Zhelonkin
+ * @license MIT
+ */
+#ifndef ZHELE_PLATFORM_CH32_COMMON_IMPL_FLASH_H
+#define ZHELE_PLATFORM_CH32_COMMON_IMPL_FLASH_H
+
+#include <cstdint>
+
+namespace Zhele
+{
+    inline constexpr uint32_t Flash::Normalize(uint32_t address)
+    {
+        return (address & AliasMask) | FLASH_BASE;
+    }
+
+    inline constexpr uint32_t Flash::PageCount()
+    {
+        return FlashSize() / PageSize(0);
+    }
+
+    inline constexpr uint32_t Flash::PageAddress(unsigned page)
+    {
+        return page * PageSize(page);
+    }
+
+    inline constexpr unsigned Flash::AddressToPage(const void* address)
+    {
+        return (reinterpret_cast<uint32_t>(address) & AliasMask) / PageSize(0);
+    }
+
+    inline void Flash::WaitWhileBusy()
+    {
+        while (FLASH->STATR & FLASH_STATR_BSY) continue;
+    }
+
+    inline bool Flash::WaitForOperation()
+    {
+        // Bounded: an operation that has already finished never shows BSY.
+        for (unsigned guard = 64; guard != 0 && (FLASH->STATR & FLASH_STATR_BSY) == 0; --guard)
+            continue;
+
+        WaitWhileBusy();
+
+        for (uint32_t timeout = OperationTimeout; timeout != 0; --timeout) {
+            if (FLASH->STATR & FLASH_STATR_EOP)
+                return true;
+        }
+
+        return false;
+    }
+
+    inline void Flash::ClearStatus()
+    {
+        FLASH->STATR = FLASH_STATR_EOP | FLASH_STATR_WRPRTERR
+    #if defined(FLASH_STATR_PGERR)
+            | FLASH_STATR_PGERR
+    #endif
+            ;
+    }
+
+    inline bool Flash::CheckAndClearStatus()
+    {
+        constexpr uint32_t errors = FLASH_STATR_WRPRTERR
+    #if defined(FLASH_STATR_PGERR)
+            | FLASH_STATR_PGERR
+    #endif
+            ;
+
+        bool result = (FLASH->STATR & errors) == 0;
+        FLASH->STATR = FLASH_STATR_EOP | errors;
+
+        return result;
+    }
+
+    inline bool Flash::Unlock()
+    {
+        if (!IsLock())
+            return true;
+
+        FLASH->KEYR = FlashKey1;
+        FLASH->KEYR = FlashKey2;
+
+        return !IsLock();
+    }
+
+    inline void Flash::Lock()
+    {
+        FLASH->CTLR |= FLASH_CTLR_LOCK;
+    }
+
+    inline bool Flash::IsLock()
+    {
+        return (FLASH->CTLR & FLASH_CTLR_LOCK) != 0;
+    }
+
+    inline bool Flash::ErasePage(uint32_t page)
+    {
+        if (page >= PageCount())
+            return false;
+
+        if (!Unlock())
+            return false;
+
+        WaitWhileBusy();
+        ClearStatus();
+
+    #if defined(ZHELE_CH32_FLASH_FAST_PROGRAMMING)
+        // A previous fast cycle must not leave its mode bits behind.
+        FLASH->CTLR &= ~(static_cast<uint32_t>(FLASH_CTLR_OPTER) | CtlrPageErase | CtlrPageProgram);
+    #endif
+
+        uint32_t address = Normalize(PageAddress(page));
+
+        FLASH->CTLR |= FLASH_CTLR_PER;
+        FLASH->ADDR = address;
+        FLASH->CTLR |= FLASH_CTLR_STRT;
+
+        bool result = WaitForOperation();
+
+        FLASH->CTLR &= ~static_cast<uint32_t>(FLASH_CTLR_PER);
+
+        result = CheckAndClearStatus() && result;
+        Lock();
+
+        return result;
+    }
+
+#if defined(ZHELE_CH32_FLASH_FAST_PROGRAMMING)
+    inline bool Flash::UnlockFast()
+    {
+        FLASH->KEYR = FlashKey1;
+        FLASH->KEYR = FlashKey2;
+
+        FLASH->MODEKEYR = FlashKey1;
+        FLASH->MODEKEYR = FlashKey2;
+
+        return !IsLock() && (FLASH->CTLR & FLASH_CTLR_FLOCK) == 0;
+    }
+
+    inline void Flash::LockFast()
+    {
+        FLASH->CTLR |= FLASH_CTLR_FLOCK;
+        FLASH->CTLR |= FLASH_CTLR_LOCK;
+    }
+
+    inline bool Flash::WriteFlash(void* dst, const void* src, unsigned size)
+    {
+        uint32_t address = Normalize(reinterpret_cast<uint32_t>(dst));
+        auto data = reinterpret_cast<const uint8_t*>(src);
+
+        if (!UnlockFast())
+            return false;
+
+        ClearStatus();
+
+        bool result = true;
+
+        while (size > 0) {
+            // A fast programming cycle always rewrites a whole page, so the words
+            // the caller does not touch are reloaded from their current content.
+            uint32_t pageAddress = address & ~(FastPageSize - 1);
+            unsigned offset = address - pageAddress;
+            unsigned chunk = FastPageSize - offset < size ? FastPageSize - offset : size;
+
+            FLASH->CTLR &= ~(static_cast<uint32_t>(FLASH_CTLR_OPTER) | CtlrPageErase);
+            FLASH->CTLR |= CtlrPageProgram;
+            FLASH->CTLR |= CtlrBufferReset;
+            WaitWhileBusy();
+
+            for (unsigned i = 0; i < FastPageSize; i += sizeof(uint32_t)) {
+                // Reading flash while the page buffer is being filled is safe —
+                // this very loop is fetched from flash. Only the programming
+                // cycle itself (STRT) stalls the core.
+                uint32_t word = *reinterpret_cast<const volatile uint32_t*>(pageAddress + i);
+
+                for (unsigned byte = 0; byte < sizeof(uint32_t); ++byte) {
+                    unsigned position = i + byte;
+                    if (position >= offset && position < offset + chunk) {
+                        reinterpret_cast<uint8_t*>(&word)[byte] = data[position - offset];
+                    }
+                }
+
+                *reinterpret_cast<volatile uint32_t*>(pageAddress + i) = word;
+                FLASH->CTLR |= CtlrBufferLoad;
+                WaitWhileBusy();
+            }
+
+            FLASH->ADDR = pageAddress;
+            FLASH->CTLR |= FLASH_CTLR_STRT;
+            bool completed = WaitForOperation();
+            FLASH->CTLR &= ~CtlrPageProgram;
+
+            if (!CheckAndClearStatus() || !completed) {
+                result = false;
+                break;
+            }
+
+            address += chunk;
+            data += chunk;
+            size -= chunk;
+        }
+
+        LockFast();
+
+        return result;
+    }
+#else
+    inline bool Flash::WriteFlash(void* dst, const void* src, unsigned size)
+    {
+        uint32_t address = Normalize(reinterpret_cast<uint32_t>(dst));
+        auto data = reinterpret_cast<const uint8_t*>(src);
+
+        // Programming granularity is a halfword, so an odd size gets its tail
+        // padded with 0xFF (an erased flash byte) and an odd address is rejected.
+        if (address & 0x01)
+            return false;
+
+        if (!Unlock())
+            return false;
+
+        WaitWhileBusy();
+        ClearStatus();
+        FLASH->CTLR |= FLASH_CTLR_PG;
+
+        bool result = true;
+        for (unsigned i = 0; i < size; i += sizeof(uint16_t)) {
+            uint8_t halfword[sizeof(uint16_t)] = {
+                data[i],
+                static_cast<uint8_t>((i + 1) < size ? data[i + 1] : 0xFF)
+            };
+
+            *reinterpret_cast<volatile uint16_t*>(address + i)
+                = static_cast<uint16_t>(halfword[0]) | static_cast<uint16_t>(halfword[1] << 8);
+
+            bool completed = WaitForOperation();
+
+            if (!CheckAndClearStatus() || !completed) {
+                result = false;
+                break;
+            }
+        }
+
+        FLASH->CTLR &= ~static_cast<uint32_t>(FLASH_CTLR_PG);
+        Lock();
+
+        return result;
+    }
+#endif
+
+    inline bool Flash::WritePage(void* dst, const void* src, unsigned size)
+    {
+        unsigned page = AddressToPage(dst);
+        uint32_t offset = (reinterpret_cast<uint32_t>(dst) & AliasMask) - PageAddress(page);
+
+        if (page >= PageCount())
+            return false;
+
+        if (offset + size > PageSize(page))
+            return false;
+
+        return WriteFlash(dst, src, size);
+    }
+
+    inline bool Flash::WritePage(unsigned page, const void* src, unsigned size, unsigned offset)
+    {
+        if (page >= PageCount())
+            return false;
+
+        if (offset + size > PageSize(page))
+            return false;
+
+        return WriteFlash(reinterpret_cast<uint8_t*>(PageAddress(page)) + offset, src, size);
+    }
+}
+
+#endif //! ZHELE_PLATFORM_CH32_COMMON_IMPL_FLASH_H

--- a/include/zhele/platform/ch32/flash.h
+++ b/include/zhele/platform/ch32/flash.h
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * Flash for CH32 — dispatches to the correct family implementation.
+ */
+#ifndef ZHELE_PLATFORM_CH32_FLASH_H
+#define ZHELE_PLATFORM_CH32_FLASH_H
+
+#include "platform_detector.h"
+
+#if defined(ZHELE_CH32_FAMILY_V0)
+#  include "v0/flash.h"
+#elif defined(ZHELE_CH32_FAMILY_V2)
+#  include "v2/flash.h"
+#elif defined(ZHELE_CH32_FAMILY_V1) || defined(ZHELE_CH32_FAMILY_V3)
+#  error "Zhele: CH32 V1/V3 flash not yet implemented. Contributions welcome."
+#else
+#  error "Zhele: CH32 family not detected. Define CH32V003 (or the correct WCH device macro)."
+#endif
+
+#endif // ZHELE_PLATFORM_CH32_FLASH_H

--- a/include/zhele/platform/ch32/v0/flash.h
+++ b/include/zhele/platform/ch32/v0/flash.h
@@ -1,0 +1,64 @@
+/**
+ * @file
+ * CH32V00x flash: 1 KB erase sector, halfword or fast-page programming.
+ *
+ * @details CH32V003 keeps the classic standard programming mode (`CTLR.PG`);
+ * the newer V00x parts (V002/V004/V005/V006/V007) dropped it and can only be
+ * programmed through the 256-byte fast page buffer, so the write path is
+ * selected here. Erase is the 1 KB `CTLR.PER` sector erase on both.
+ */
+#ifndef ZHELE_PLATFORM_CH32_V0_FLASH_H
+#define ZHELE_PLATFORM_CH32_V0_FLASH_H
+
+#include <ch32v00x.h>
+
+// Standard (halfword) programming is gone on the new V00x parts: no CTLR.PG.
+#if !defined(FLASH_CTLR_PG)
+#  define ZHELE_CH32_FLASH_FAST_PROGRAMMING 1
+#endif
+
+#include "../common/flash.h"
+
+namespace Zhele
+{
+    /// @brief Max flash frequence without wait states
+    const static uint32_t MaxFlashFrequence = 24000000;
+
+    inline void Flash::ConfigureFrequence(uint32_t frequence)
+    {
+    #if defined(CH32V00X)
+        // V00x: 0 WS up to 8 MHz, 1 WS up to 24 MHz, 2 WS above (RM, FLASH_ACTLR).
+        uint32_t ws = frequence <= 8000000 ? 0 : (frequence <= MaxFlashFrequence ? 1 : 2);
+    #else
+        // V003: 0 WS up to 24 MHz, 1 WS above.
+        uint32_t ws = frequence <= MaxFlashFrequence ? 0 : 1;
+    #endif
+
+        FLASH->ACTLR = (FLASH->ACTLR & ~static_cast<uint32_t>(FLASH_ACTLR_LATENCY)) | ws;
+    }
+
+    inline constexpr uint32_t Flash::FlashSize()
+    {
+    #if defined(ZHELE_FLASH_SIZE)
+        return ZHELE_FLASH_SIZE;
+    #elif defined(CH32V003) || defined(CH32V002)
+        return 16 * 1024;
+    #elif defined(CH32V004) || defined(CH32V005)
+        return 32 * 1024;
+    #elif defined(CH32V006) || defined(CH32V007_M007)
+        return 62 * 1024;
+    #else
+        // No chip macro to go by (only the family one). 16 KB is the smallest V0
+        // part, so page bounds stay conservative until the consumer says otherwise.
+        #warning "Zhele: unknown CH32V00x flash size, assuming 16 KB. Define ZHELE_FLASH_SIZE (in bytes)."
+        return 16 * 1024;
+    #endif
+    }
+
+    inline constexpr uint32_t Flash::PageSize(unsigned)
+    {
+        return 1024;
+    }
+}
+
+#endif // ZHELE_PLATFORM_CH32_V0_FLASH_H

--- a/include/zhele/platform/ch32/v2/flash.h
+++ b/include/zhele/platform/ch32/v2/flash.h
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * CH32V20x flash: 4 KB erase sector, halfword programming.
+ *
+ * @details The V20x FPEC keeps the standard programming mode (`CTLR.PG`), but
+ * unlike the V0 parts its `CTLR.PER` erases a 4 KB sector, not 1 KB.
+ */
+#ifndef ZHELE_PLATFORM_CH32_V2_FLASH_H
+#define ZHELE_PLATFORM_CH32_V2_FLASH_H
+
+#include <ch32v20x.h>
+
+#include "../common/flash.h"
+
+namespace Zhele
+{
+    inline void Flash::ConfigureFrequence(uint32_t)
+    {
+        // Nothing to do: the V20x flash has no wait states. Its register map
+        // starts at KEYR — there is no ACTLR (see the CH32V203/CH32V208 SVD, and
+        // note that the WCH CMSIS header declares no bits for it either, while
+        // the ACTLR field it does declare in the struct always reads back 0).
+    }
+
+    inline constexpr uint32_t Flash::FlashSize()
+    {
+    #if defined(ZHELE_FLASH_SIZE)
+        return ZHELE_FLASH_SIZE;
+    #elif defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+        return 128 * 1024;
+    #else
+        // D6 line (CH32V203x6 / x8). Override with ZHELE_FLASH_SIZE for smaller parts.
+        return 64 * 1024;
+    #endif
+    }
+
+    inline constexpr uint32_t Flash::PageSize(unsigned)
+    {
+        return 4096;
+    }
+}
+
+#endif // ZHELE_PLATFORM_CH32_V2_FLASH_H


### PR DESCRIPTION
Adds `Zhele::Flash` for CH32, ported from the standalone driver in the `ch32v003_base` project and generalised to the two families Zhele supports.

- `platform/ch32/flash.h` dispatches to `v0/` (1 KB sector) or `v2/` (4 KB sector).
- V003 and V20x use standard halfword programming (`CTLR.PG`). The newer V00x parts (V002/4/5/6/7) have no `PG` at all, so there the write path uses the 256-byte fast page buffer (`MODEKEYR` + `BUF_RST`/`BUF_LOAD` + `PAGE_PG`). Words outside the caller's range are loaded as `0xFFFFFFFF`, which leaves those cells untouched.
- Erase/program completion is taken from `STATR.BSY` (polled for it to *appear* first — it needs a few cycles to rise) and then `STATR.EOP`, which hardware raises without `CTLR.EOPIE`.
- `SysClock::SelectClockSource()` now configures flash wait states, as it already did on STM32: wait states are raised before speeding up and lowered only after slowing down. V20x has no `ACTLR` register at all, so there it is a documented no-op.
- The fast-mode `CTLR` bits are spelled out instead of taken from the WCH V00x header, which casts them to `uint16_t` and truncates them to zero.

Note documented in `ErasePage()`: on CH32V203 an erased sector reads back as `0xE339E339` in every word until something is programmed into it, so an erase must not be confirmed by blank-checking for `0xFF`. V003/V006 read `0xFF` as expected.

Verified on hardware (erase, write, read-back, persistence across power cycles) on CH32V203, CH32V006 and CH32V003; wait-state setup checked at 48 MHz on V003 (`ACTLR = 1`) and V006 (`ACTLR = 2`).